### PR TITLE
extra i2c header required on my ubuntu 18 install

### DIFF
--- a/common/i2c_interface.h
+++ b/common/i2c_interface.h
@@ -15,6 +15,7 @@
 
 // I2C includes
 #include <linux/i2c-dev.h>
+#include <i2c/smbus.h>
 
 namespace GeNNRobotics {
 //----------------------------------------------------------------------------


### PR DESCRIPTION
This was required for the I2C code to build (after installing libi2c-dev) on my new Ubuntu 18 install (kernel 4.15ish) - does this work on your various machines (especially arch!)? If it does, don't merge - I need to test on jetsons n'stuff!