### PR TITLE
Fix i2c code so it works on new and old kernels

### DIFF
--- a/camera_recorder/.gitignore
+++ b/camera_recorder/.gitignore
@@ -1,0 +1,1 @@
+/camera_recorder

--- a/camera_recorder/build.sh
+++ b/camera_recorder/build.sh
@@ -1,1 +1,1 @@
-g++ camera_recorder.cc -std=c++11 -DI2C `pkg-config --libs --cflags opencv` -o camera_recorder
+g++ camera_recorder.cc -std=c++11 -pthread -DI2C `pkg-config --libs --cflags opencv` -o camera_recorder

--- a/common/i2c_interface.h
+++ b/common/i2c_interface.h
@@ -15,7 +15,6 @@
 
 // I2C includes
 #include <linux/i2c-dev.h>
-#include <i2c/smbus.h>
 
 // This extra header is needed after Ubuntu 16.04 (newer kernel?)
 #ifndef I2C_SMBUS_BYTE_DATA

--- a/common/i2c_interface.h
+++ b/common/i2c_interface.h
@@ -15,6 +15,7 @@
 
 // I2C includes
 #include <linux/i2c-dev.h>
+#include <i2c/smbus.h>
 
 namespace GeNNRobotics {
 //----------------------------------------------------------------------------

--- a/common/i2c_interface.h
+++ b/common/i2c_interface.h
@@ -17,6 +17,11 @@
 #include <linux/i2c-dev.h>
 #include <i2c/smbus.h>
 
+// This extra header is needed after Ubuntu 16.04 (newer kernel?)
+#ifndef I2C_SMBUS_BYTE_DATA
+#include <i2c/smbus.h>
+#endif
+
 namespace GeNNRobotics {
 //----------------------------------------------------------------------------
 // I2CInterface


### PR DESCRIPTION
I've added an #ifdef which seems to fix the i2c code so it compiles on Ubuntu 16.04 and on my Arch system.