### PR TITLE
Generic image database header

### DIFF
--- a/ant_world_db_creator/ant_world_db_creator.cc
+++ b/ant_world_db_creator/ant_world_db_creator.cc
@@ -138,10 +138,10 @@ int main(int argc, char *argv[])
     const auto &worldMaxBound = renderer.getWorld().getMaxBound();
 
     // Create ImageDatabaseRecorder
-    ImageDatabaseRecorder<decltype(agent)> database(databaseName, followRoute, agent);
+    ImageDatabaseRecorder database(databaseName, followRoute);
 
     // Host OpenCV array to hold pixels read from screen
-    cv::Mat snapshot(renderHeight, renderWidth, CV_8UC3);
+    cv::Mat frame(renderHeight, renderWidth, CV_8UC3);
 
     size_t routePosition = 0;
     size_t currentGridX = 0;
@@ -162,8 +162,15 @@ int main(int argc, char *argv[])
             y = worldMinBound[1] + (gridSpacing * currentGridY);
         }
 
+        // Update pose
+        agent.setPosition(x, y, z);
+        agent.setAttitude(heading, 0_deg, 0_deg);
+
+        // Read frame
+        agent.readFrame(frame);
+
         // Write to image database
-        database.savePosition(x, y, z, heading);
+        database.saveImage(frame, x, y, z, heading);
 
         // Poll for and process events
         glfwPollEvents();

--- a/ant_world_db_creator/ant_world_db_creator.cc
+++ b/ant_world_db_creator/ant_world_db_creator.cc
@@ -194,7 +194,6 @@ int main(int argc, char *argv[])
                   << heading.value() << ", " << filename << std::endl;
 
         // Write image file
-        cv::flip(snapshot, snapshot, 0);
         cv::imwrite((savePath / filename).str(), snapshot);
 
         // Poll for and process events

--- a/common/image_database_recorder.h
+++ b/common/image_database_recorder.h
@@ -1,0 +1,68 @@
+// Standard C includes
+#include <cstdio>
+
+// Standard C++ includes
+#include <fstream>
+#include <iostream>
+#include <stdexcept>
+#include <string>
+#include <tuple>
+
+// OpenCV
+#include <opencv2/opencv.hpp>
+
+// Third-party includes
+#include "../third_party/path.h"
+#include "../third_party/units.h"
+
+namespace BoBRobotics {
+using namespace units::length;
+using namespace units::angle;
+
+template<class AgentType>
+class ImageDatabaseRecorder
+{
+public:
+    ImageDatabaseRecorder(std::string databaseName, bool isRoute, AgentType &agent)
+      : m_Agent(agent), m_DatabaseName(databaseName), m_IsRoute(isRoute)
+    {
+        filesystem::path databasePath = databaseName;
+        filesystem::create_directory(databasePath);
+
+        // Write CSV header
+        m_CSVStream.open(databasePath / (databaseName + ".csv"));
+        m_CSVStream << "X [mm], Y [mm], Z [mm], Heading [degrees], Filename" << std::endl;
+    }
+
+    void savePosition(millimeter_t x, millimeter_t y, millimeter_t z, degree_t heading = 0_deg)
+    {
+        m_Agent.setPosition(x, y, z);
+        m_Agent.setAttitude(heading, 0_deg, 0_deg);
+
+        // Get image file name
+        char filename[255];
+        if (isRoute) {
+            snprintf(filename, 255, "%s_%04d", m_DatabaseName.c_str(), m_RouteCount++);
+        } else {
+            snprintf(filename, 255, "%s_%05d_%05d_%05d.png",
+                     m_DatabaseName.c_str(), (int) round(x), (int) round(y), (int) round(z));
+        }
+        auto imagePath = filesystem::path(m_DatabaseName) / filename;
+
+        // Write current view to imagePath
+        agent.readFrameSync(m_OutFrame);
+        cv::imwrite(imagePath, m_OutFrame);
+
+        // Write image file info to CSV file
+        m_CSVStream << x.value() << ", " << y.value() << ", " << z.value() << ", "
+                    << heading.value() << ", " << filename << std::endl;
+    }
+
+private:
+    AgentType m_Agent;
+    std::string m_DatabaseName;
+    std::ofstream m_CSVStream;
+    cv::Mat m_OutFrame;
+    int m_RouteCount = 0;
+}; // ImageDatabaseRecorder
+} // BoBRobotics

--- a/common/image_database_recorder.h
+++ b/common/image_database_recorder.h
@@ -58,7 +58,7 @@ public:
 private:
     std::string m_DatabaseName;
     std::ofstream m_CSVStream;
-    bool m_IsRoute;
+    const bool m_IsRoute;
     int m_RouteCount = 0;
 }; // ImageDatabaseRecorder
 } // BoBRobotics

--- a/common/image_database_recorder.h
+++ b/common/image_database_recorder.h
@@ -3,9 +3,11 @@
 
 // Standard C++ includes
 #include <fstream>
+#include <iomanip>
 #include <iostream>
 #include <stdexcept>
 #include <string>
+#include <sstream>
 #include <tuple>
 
 // OpenCV
@@ -38,17 +40,17 @@ public:
     void saveImage(cv::Mat &frame, millimeter_t x, millimeter_t y, millimeter_t z, degree_t heading)
     {
         // Get image file name
-        char filename[255];
+        std::string filename;
         if (m_IsRoute) {
-            snprintf(filename, 255, "%s_%04d", m_DatabaseName.c_str(), m_RouteCount++);
+            char buf[255];
+            snprintf(buf, 255, "%s_%04d.png", m_DatabaseName.c_str(), m_RouteCount++);
+            filename = std::string(buf);
         } else {
-            snprintf(filename, 255, "%s_%05d_%05d_%05d.png",
-                     m_DatabaseName.c_str(), (int) round(x), (int) round(y), (int) round(z));
+            filename = m_DatabaseName + "_" + zeroPad(x) + "_" + zeroPad(y) + "_" + zeroPad(z) + ".png";
         }
-        auto imagePath = filesystem::path(m_DatabaseName) / filename;
 
-        // Write current view to imagePath
-        cv::imwrite(imagePath.str(), frame);
+        // Write current view to file
+        cv::imwrite((filesystem::path(m_DatabaseName) / filename).str(), frame);
 
         // Write image file info to CSV file
         m_CSVStream << x.value() << ", " << y.value() << ", " << z.value() << ", "
@@ -60,5 +62,14 @@ private:
     std::ofstream m_CSVStream;
     const bool m_IsRoute;
     int m_RouteCount = 0;
+
+    static std::string zeroPad(millimeter_t value)
+    {
+        int ival = static_cast<int>(round(value));
+        char num[12];
+        snprintf(&num[1], 11, "%05d", abs(ival));
+        num[0] = (ival < 0) ? '-' : '+';
+        return std::string(num);
+    }
 }; // ImageDatabaseRecorder
 } // BoBRobotics

--- a/common/image_database_recorder.h
+++ b/common/image_database_recorder.h
@@ -18,6 +18,8 @@
 namespace BoBRobotics {
 using namespace units::length;
 using namespace units::angle;
+using namespace units::math;
+using namespace units::literals;
 
 template<class AgentType>
 class ImageDatabaseRecorder
@@ -30,7 +32,7 @@ public:
         filesystem::create_directory(databasePath);
 
         // Write CSV header
-        m_CSVStream.open(databasePath / (databaseName + ".csv"));
+        m_CSVStream.open((databasePath / (databaseName + ".csv")).str());
         m_CSVStream << "X [mm], Y [mm], Z [mm], Heading [degrees], Filename" << std::endl;
     }
 
@@ -41,7 +43,7 @@ public:
 
         // Get image file name
         char filename[255];
-        if (isRoute) {
+        if (m_IsRoute) {
             snprintf(filename, 255, "%s_%04d", m_DatabaseName.c_str(), m_RouteCount++);
         } else {
             snprintf(filename, 255, "%s_%05d_%05d_%05d.png",
@@ -50,8 +52,8 @@ public:
         auto imagePath = filesystem::path(m_DatabaseName) / filename;
 
         // Write current view to imagePath
-        agent.readFrameSync(m_OutFrame);
-        cv::imwrite(imagePath, m_OutFrame);
+        m_Agent.readFrameSync(m_OutFrame);
+        cv::imwrite(imagePath.str(), m_OutFrame);
 
         // Write image file info to CSV file
         m_CSVStream << x.value() << ", " << y.value() << ", " << z.value() << ", "
@@ -63,6 +65,7 @@ private:
     std::string m_DatabaseName;
     std::ofstream m_CSVStream;
     cv::Mat m_OutFrame;
+    bool m_IsRoute;
     int m_RouteCount = 0;
 }; // ImageDatabaseRecorder
 } // BoBRobotics

--- a/libantworld/agent.h
+++ b/libantworld/agent.h
@@ -56,7 +56,7 @@ public:
         m_Attitude[2] = roll;
     }
 
-    bool readFrame(cv::Mat &frame)
+    virtual bool readFrame(cv::Mat &frame) override
     {
         // Clear colour and depth buffer
         glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);

--- a/libantworld/agent.h
+++ b/libantworld/agent.h
@@ -21,7 +21,7 @@ using namespace units::length;
 using namespace units::literals;
 
 class AntAgent
-  : Video::OpenGL
+  : public Video::OpenGL
 {
 public:
     AntAgent(GLFWwindow *window, Renderer &renderer, GLsizei readWidth, GLsizei readHeight)

--- a/video/input.h
+++ b/video/input.h
@@ -1,11 +1,15 @@
 #pragma once
 
-// C++ includes
+// Standard C includes
 #include <cstdlib>
+
+// Standard C++ includes
+#include <chrono>
 #include <iostream>
 #include <memory>
 #include <stdexcept>
 #include <string>
+#include <thread>
 #include <vector>
 
 // OpenCV
@@ -95,6 +99,13 @@ public:
         }
         else {
             return false;
+        }
+    }
+
+    virtual void readFrameSync(cv::Mat &outFrame)
+    {
+        while (!readFrame(outFrame)) {
+            std::this_thread::sleep_for(std::chrono::milliseconds(10));
         }
     }
 

--- a/video/input.h
+++ b/video/input.h
@@ -1,15 +1,11 @@
 #pragma once
 
-// Standard C includes
+// C++ includes
 #include <cstdlib>
-
-// Standard C++ includes
-#include <chrono>
 #include <iostream>
 #include <memory>
 #include <stdexcept>
 #include <string>
-#include <thread>
 #include <vector>
 
 // OpenCV
@@ -99,13 +95,6 @@ public:
         }
         else {
             return false;
-        }
-    }
-
-    virtual void readFrameSync(cv::Mat &outFrame)
-    {
-        while (!readFrame(outFrame)) {
-            std::this_thread::sleep_for(std::chrono::milliseconds(10));
         }
     }
 

--- a/video/opengl.h
+++ b/video/opengl.h
@@ -48,6 +48,9 @@ public:
         // **TODO** it should be theoretically possible to go directly from frame buffer to GpuMat
         glReadPixels(m_ReadX, m_ReadY, m_ReadWidth, m_ReadHeight,
                      GL_BGR, GL_UNSIGNED_BYTE, outFrame.data);
+        
+        // Flip image vertically
+        cv::flip(outFrame, outFrame, 0);
 
         return true;
     }


### PR DESCRIPTION
I've taken the code for writing to the image database (i.e. saving an image and adding a line to the CSV file) and put it in its own header in a generic form.

Now you can do:
```C++
ImageDatabaseRecorder database("database_name", /*followRoute=*/ false);
...
database.saveImage(frame, 0.5_m, 0.5_m, 0_m, 0_deg);
```

The main impetus for this was is so that Norbert can save his image databases from the robot in the same form.