### PR TITLE
Build updates

### DIFF
--- a/common/flags.mk
+++ b/common/flags.mk
@@ -50,3 +50,9 @@ ifdef WITH_MATPLOTLIBCPP
 	CXXFLAGS += $(shell $(PYTHON_CONFIG) --includes) -I$(PYTHON_NUMPY_INCLUDE)
 	LINK_FLAGS += $(shell $(PYTHON_CONFIG) --libs)
 endif
+
+ifdef WITH_I2C
+	ifeq (0,$(shell ../../common/is_i2c_tools_new.sh; echo $$?))
+	LINK_FLAGS += -li2c
+	endif
+endif

--- a/common/flags.mk
+++ b/common/flags.mk
@@ -18,6 +18,9 @@ else
 	CXXFLAGS += -O2
 endif
 
+# Improves build time
+CXXFLAGS += -pipe
+
 # Linking flags (-lm and -lstdc++ needed for clang)
 LINK_FLAGS += -lm -lstdc++ -pthread
 

--- a/common/flags.mk
+++ b/common/flags.mk
@@ -21,6 +21,14 @@ endif
 # Improves build time
 CXXFLAGS += -pipe
 
+# Enable only a subset of functionality in units.h to speed up compile time
+CXXFLAGS += -DDISABLE_PREDEFINED_UNITS \
+		-DENABLE_PREDEFINED_LENGTH_UNITS \
+		-DENABLE_PREDEFINED_TIME_UNITS \
+		-DENABLE_PREDEFINED_ANGLE_UNITS \
+		-DENABLE_PREDEFINED_VELOCITY_UNITS \
+		-DENABLE_PREDEFINED_ANGULAR_VELOCITY_UNITS
+
 # Linking flags (-lm and -lstdc++ needed for clang)
 LINK_FLAGS += -lm -lstdc++ -pthread
 

--- a/examples/lm9ds1/Makefile
+++ b/examples/lm9ds1/Makefile
@@ -1,10 +1,7 @@
 NO_OPENCV := 1
+WITH_I2C := 1
 include ../../common/flags.mk
 CXXFLAGS += -I../..
-
-ifeq (0,$(shell ../../common/is_i2c_tools_new.sh; echo $$?))
-LINK_FLAGS += -li2c
-endif
 
 EXECUTABLE := lm9ds1_test
 

--- a/projects/stone_cx/.gitignore
+++ b/projects/stone_cx/.gitignore
@@ -3,3 +3,5 @@
 /simulator_wrapper
 /simulatorReplay
 /simulatorVicon
+/simulatorRobot
+/simulatorRobotDeadReckon

--- a/projects/stone_cx/MakefileRobot
+++ b/projects/stone_cx/MakefileRobot
@@ -1,9 +1,10 @@
+WITH_I2C := 1
+include ../../common/flags.mk
+CXXFLAGS += -I../..
+
 EXECUTABLE      := simulatorRobot
 SOURCES         := simulatorRobot.cc simulatorCommon.cc robotCommon.cc
-LINK_FLAGS      := `pkg-config --libs opencv`
-CXXFLAGS        := `pkg-config --cflags opencv` -pthread -I../..
-CPU_ONLY        =1
-CPP_STANDARD    =c++14
+CPU_ONLY        = 1
 
 ifdef RECORD_ELECTROPHYS
     CXXFLAGS += -DRECORD_ELECTROPHYS

--- a/projects/stone_cx/MakefileRobotDeadReckon
+++ b/projects/stone_cx/MakefileRobotDeadReckon
@@ -1,9 +1,10 @@
+WITH_I2C := 1
+include ../../common/flags.mk
+CXXFLAGS += -I../..
+
 EXECUTABLE      := simulatorRobotDeadReckon
 SOURCES         := simulatorRobotDeadReckon.cc simulatorCommon.cc robotCommon.cc visualizationCommon.cc
-LINK_FLAGS      := `pkg-config --libs opencv`
-CXXFLAGS        := -pthread `pkg-config --cflags opencv` -I../..
-CPU_ONLY        =1
-CPP_STANDARD    =c++14
+CPU_ONLY        = 1
 
 ifdef RECORD_ELECTROPHYS
     CXXFLAGS += -DRECORD_ELECTROPHYS

--- a/projects/stone_cx/MakefileVicon
+++ b/projects/stone_cx/MakefileVicon
@@ -1,9 +1,10 @@
+WITH_I2C := 1
+include ../../common/flags.mk
+CXXFLAGS += -I../..
+
 EXECUTABLE      := simulatorVicon
 SOURCES         := simulatorVicon.cc simulatorCommon.cc robotCommon.cc
-LINK_FLAGS      := `pkg-config --libs opencv`
-CXXFLAGS        := `pkg-config --cflags opencv` -pthread -I../..
-CPU_ONLY        =1
-CPP_STANDARD    =c++14
+CPU_ONLY        = 1
 
 ifdef RECORD_ELECTROPHYS
     CXXFLAGS += -DRECORD_ELECTROPHYS


### PR DESCRIPTION
This is just for some tiny changes to the build system.

- It turns out you can "opt in" to compiling different unit types. If we disable all except the ones we're using it massively improves build times for bits of code using units.h. If we ever decide we want any other unit types (e.g. acceleration) we can always adjust this.
- I've put the i2c makefile hacks into common/flags.mk, so that they can be used elsewhere. I've updated the robot versions of makefiles in stone_cx to use this, so they now compile for me