### PR TITLE
AntWorld rotater + other navigation code updates

### DIFF
--- a/examples/perfect_memory/.gitignore
+++ b/examples/perfect_memory/.gitignore
@@ -1,2 +1,3 @@
 /perfect_memory_test
+/perfect_memory_antworld_test
 /plot_ridf

--- a/examples/perfect_memory/Makefile
+++ b/examples/perfect_memory/Makefile
@@ -2,6 +2,10 @@ WITH_MATPLOTLIBCPP := 1
 include ../../common/flags.mk
 CXXFLAGS += -I../..
 
+ifndef DEBUG
+CXXFLAGS += -O3
+endif
+
 EXECUTABLE := perfect_memory_test
 
 .PHONY: all clean
@@ -11,7 +15,7 @@ all: $(EXECUTABLE) plot_ridf
 -include $(EXECUTABLE).d
 
 $(EXECUTABLE): $(EXECUTABLE).cc $(EXECUTABLE).d
-	$(CXX) -o $(EXECUTABLE) $(EXECUTABLE).cc $(CXXFLAGS) $(LINK_FLAGS) -O3
+	$(CXX) -o $(EXECUTABLE) $(EXECUTABLE).cc $(CXXFLAGS) $(LINK_FLAGS)
 
 -include plot_ridf.d
 

--- a/examples/perfect_memory/Makefile
+++ b/examples/perfect_memory/Makefile
@@ -8,14 +8,19 @@ endif
 
 EXECUTABLE := perfect_memory_test
 
-.PHONY: all clean
+.PHONY: all clean libantworld
 
-all: $(EXECUTABLE) plot_ridf
+all: $(EXECUTABLE) perfect_memory_antworld_test plot_ridf
 
 -include $(EXECUTABLE).d
 
 $(EXECUTABLE): $(EXECUTABLE).cc $(EXECUTABLE).d
 	$(CXX) -o $(EXECUTABLE) $(EXECUTABLE).cc $(CXXFLAGS) $(LINK_FLAGS)
+
+-include perfect_memory_antworld_test.d
+
+perfect_memory_antworld_test: perfect_memory_antworld_test.cc perfect_memory_antworld_test.d libantworld
+	$(CXX) -o perfect_memory_antworld_test perfect_memory_antworld_test.cc $(CXXFLAGS) $(LINK_FLAGS) -L../../libantworld -lantworld -lglfw -lGL -lGLU -lGLEW
 
 -include plot_ridf.d
 
@@ -25,4 +30,7 @@ plot_ridf: plot_ridf.cc plot_ridf.d
 %.d: ;
 
 clean:
-	rm -f $(EXECUTABLE) plot_ridf *.d
+	rm -f $(EXECUTABLE) plot_ridf perfect_memory_antworld_test *.d
+
+libantworld:
+	$(MAKE) -C ../../libantworld

--- a/examples/perfect_memory/Makefile
+++ b/examples/perfect_memory/Makefile
@@ -11,7 +11,7 @@ all: $(EXECUTABLE) plot_ridf
 -include $(EXECUTABLE).d
 
 $(EXECUTABLE): $(EXECUTABLE).cc $(EXECUTABLE).d
-	$(CXX) -o $(EXECUTABLE) $(EXECUTABLE).cc $(CXXFLAGS) $(LINK_FLAGS)
+	$(CXX) -o $(EXECUTABLE) $(EXECUTABLE).cc $(CXXFLAGS) $(LINK_FLAGS) -O3
 
 -include plot_ridf.d
 

--- a/examples/perfect_memory/perfect_memory_antworld_test.cc
+++ b/examples/perfect_memory/perfect_memory_antworld_test.cc
@@ -99,20 +99,43 @@ main()
     const cv::Size imSize(renderWidth, renderHeight);
     degree_t heading;
 
-    std::cout << "Testing with best-matching snapshot method..." << std::endl;
+    {
+        std::cout << "Using ant world rotater..." << std::endl;
+        PerfectMemory<BestMatchingSnapshot, AbsDiff, AntWorldRotater> pm(imSize);
+        trainRoute(pm);
 
-    // Default algorithm: find best-matching snapshot, use abs diff
-    PerfectMemory<BestMatchingSnapshot, AbsDiff, AntWorldRotater> pm(imSize);
-    trainRoute(pm);
+        size_t snapshot;
+        float difference;
+        std::vector<std::vector<float>> allDifferences;
+        std::tie(heading, snapshot, difference, allDifferences) = pm.getHeading(agent, 2_deg);
+        std::cout << "Heading: " << heading << std::endl;
+        std::cout << "Best-matching snapshot: #" << snapshot << std::endl;
+        std::cout << "Difference score: " << difference << std::endl;
 
-    size_t snapshot;
-    float difference;
-    std::vector<std::vector<float>> allDifferences;
-    std::tie(heading, snapshot, difference, allDifferences) = pm.getHeading(agent, 2_deg);
-    std::cout << "Heading: " << heading << std::endl;
-    std::cout << "Best-matching snapshot: #" << snapshot << std::endl;
-    std::cout << "Difference score: " << difference << std::endl;
+        // Plot RIDF
+        plotRIDF(allDifferences[snapshot]);
+        std::cout << std::endl;
+    }
 
-    // Plot RIDF
-    plotRIDF(allDifferences[snapshot]);
+    {
+        std::cout << "Using in silico rotater..." << std::endl;
+        PerfectMemory<BestMatchingSnapshot, AbsDiff, InSilicoRotater> pm(imSize);
+        trainRoute(pm);
+
+        agent.setAttitude(0_deg, 0_deg, 0_deg);
+        cv::Mat fr;
+        agent.readGreyscaleFrame(fr);
+
+        size_t snapshot;
+        float difference;
+        std::vector<std::vector<float>> allDifferences;
+        std::tie(heading, snapshot, difference, allDifferences) = pm.getHeading(fr);
+        std::cout << "Heading: " << heading << std::endl;
+        std::cout << "Best-matching snapshot: #" << snapshot << std::endl;
+        std::cout << "Difference score: " << difference << std::endl;
+
+        // Plot RIDF
+        plotRIDF(allDifferences[snapshot]);
+        std::cout << std::endl;
+    }
 }

--- a/examples/perfect_memory/perfect_memory_antworld_test.cc
+++ b/examples/perfect_memory/perfect_memory_antworld_test.cc
@@ -1,0 +1,114 @@
+// Standard C++ includes
+#include <iostream>
+
+// BoB robotics includes
+#include "navigation/antworld_rotater.h"
+#include "navigation/perfect_memory.h"
+
+using namespace BoBRobotics;
+using namespace BoBRobotics::Navigation;
+
+void
+handleGLFWError(int errorNumber, const char *message)
+{
+    std::cerr << "GLFW error number:" << errorNumber << ", message:" << message << std::endl;
+}
+
+void
+handleGLError(GLenum, GLenum, GLuint, GLenum, GLsizei, const GLchar *message, const void *)
+{
+    throw std::runtime_error(message);
+}
+
+template<typename T>
+void
+trainRoute(T &pm)
+{
+    // Load snapshots
+    pm.trainRoute("../../tools/ant_world_db_creator/ant1_route1", true);
+    std::cout << "Loaded " << pm.getNumSnapshots() << " snapshots" << std::endl;
+}
+
+int
+main()
+{
+    /*
+     * I've set the width of the image to be the same as the (raw) unwrapped
+     * images we get from the robot gantry, but the height is greater (cf. 58)
+     * because I wanted to keep the aspect ratio as it was (200x40).
+     *      -- AD
+     */
+    const unsigned int renderWidth = 180;
+    const unsigned int renderHeight = 50;
+
+    // Set GLFW error callback
+    glfwSetErrorCallback(handleGLFWError);
+
+    // Initialize the library
+    if (!glfwInit()) {
+        std::cerr << "Failed to initialize GLFW" << std::endl;
+        return EXIT_FAILURE;
+    }
+
+    // Prevent window being resized
+    glfwWindowHint(GLFW_RESIZABLE, false);
+
+    // Create a windowed mode window and its OpenGL context
+    GLFWwindow *window = glfwCreateWindow(renderWidth, renderHeight, "Ant world", nullptr, nullptr);
+    if (!window) {
+        glfwTerminate();
+        std::cerr << "Failed to create window" << std::endl;
+        return EXIT_FAILURE;
+    }
+
+    // Make the window's context current
+    glfwMakeContextCurrent(window);
+
+    // Initialize GLEW
+    if (glewInit() != GLEW_OK) {
+        std::cerr << "Failed to initialize GLEW" << std::endl;
+        return EXIT_FAILURE;
+    }
+
+    // Enable VSync
+    glfwSwapInterval(1);
+
+    glDebugMessageCallback(handleGLError, nullptr);
+
+    // Set clear colour to match matlab and enable depth test
+    glClearColor(0.0f, 1.0f, 1.0f, 1.0f);
+    glEnable(GL_DEPTH_TEST);
+    glLineWidth(4.0);
+    glPointSize(4.0);
+
+    glEnable(GL_CULL_FACE);
+    glCullFace(GL_BACK);
+
+    glEnable(GL_TEXTURE_2D);
+
+    // Create renderer
+    AntWorld::Renderer renderer(256, 0.001, 1000.0, 360_deg);
+    renderer.getWorld().load("../../libantworld/world5000_gray.bin",
+                             {0.0f, 1.0f, 0.0f}, {0.898f, 0.718f, 0.353f});
+
+    // Create agent object
+    AntWorld::AntAgent agent(window, renderer, renderWidth, renderHeight);
+    agent.setPosition(5_m, 5_m, 10_mm);
+
+    const cv::Size imSize(renderWidth, renderHeight);
+    degree_t heading;
+
+    std::cout << "Testing with best-matching snapshot method..." << std::endl;
+
+    // Default algorithm: find best-matching snapshot, use abs diff
+    PerfectMemory<BestMatchingSnapshot, AbsDiff, AntWorldRotater> pm(imSize);
+    trainRoute(pm);
+
+    size_t snapshot;
+    float difference;
+    std::vector<std::vector<float>> allDifferences;
+    std::tie(heading, snapshot, difference, allDifferences) = pm.getHeading(agent, 2_deg);
+    std::cout << "Heading: " << heading << std::endl;
+    std::cout << "Best-matching snapshot: #" << snapshot << std::endl;
+    std::cout << "Difference score: " << difference << std::endl;
+}

--- a/examples/perfect_memory/perfect_memory_antworld_test.cc
+++ b/examples/perfect_memory/perfect_memory_antworld_test.cc
@@ -101,7 +101,7 @@ main()
 
     {
         std::cout << "Using ant world rotater..." << std::endl;
-        PerfectMemory<BestMatchingSnapshot, AbsDiff, AntWorldRotater> pm(imSize);
+        PerfectMemory<BestMatchingSnapshot, AntWorldRotater> pm(imSize);
         trainRoute(pm);
 
         size_t snapshot;
@@ -119,7 +119,7 @@ main()
 
     {
         std::cout << "Using in silico rotater..." << std::endl;
-        PerfectMemory<BestMatchingSnapshot, AbsDiff, InSilicoRotater> pm(imSize);
+        PerfectMemory<BestMatchingSnapshot, InSilicoRotater> pm(imSize);
         trainRoute(pm);
 
         agent.setAttitude(0_deg, 0_deg, 0_deg);

--- a/examples/perfect_memory/perfect_memory_antworld_test.cc
+++ b/examples/perfect_memory/perfect_memory_antworld_test.cc
@@ -4,6 +4,7 @@
 // BoB robotics includes
 #include "navigation/antworld_rotater.h"
 #include "navigation/perfect_memory.h"
+#include "navigation/plot.h"
 
 using namespace BoBRobotics;
 using namespace BoBRobotics::Navigation;
@@ -111,4 +112,7 @@ main()
     std::cout << "Heading: " << heading << std::endl;
     std::cout << "Best-matching snapshot: #" << snapshot << std::endl;
     std::cout << "Difference score: " << difference << std::endl;
+
+    // Plot RIDF
+    plotRIDF(allDifferences[snapshot]);
 }

--- a/examples/perfect_memory/perfect_memory_antworld_test.cc
+++ b/examples/perfect_memory/perfect_memory_antworld_test.cc
@@ -93,7 +93,7 @@ main()
 
     // Create agent object
     AntWorld::AntAgent agent(window, renderer, renderWidth, renderHeight);
-    agent.setPosition(5_m, 5_m, 10_mm);
+    agent.setPosition(5.5_m, 4_m, 10_mm);
 
     const cv::Size imSize(renderWidth, renderHeight);
     degree_t heading;

--- a/examples/perfect_memory/perfect_memory_test.cc
+++ b/examples/perfect_memory/perfect_memory_test.cc
@@ -11,10 +11,10 @@ using namespace BoBRobotics::Navigation;
 
 template<typename T>
 void
-loadSnapshots(T &pm)
+trainRoute(T &pm)
 {
     // Load snapshots
-    pm.loadSnapshots("../../tools/ant_world_db_creator/ant1_route1", true);
+    pm.trainRoute("../../tools/ant_world_db_creator/ant1_route1", true);
     std::cout << "Loaded " << pm.getNumSnapshots() << " snapshots" << std::endl;
 }
 
@@ -30,7 +30,7 @@ main()
 
         // Default algorithm: find best-matching snapshot, use abs diff
         PerfectMemory<> pm(imSize);
-        loadSnapshots(pm);
+        trainRoute(pm);
 
         // Time testing phase
         Timer<> t{ "Time taken for testing: " };
@@ -48,7 +48,7 @@ main()
     {
         std::cout << std::endl << "Testing with RMS image difference..." << std::endl;
         PerfectMemory<BestMatchingSnapshot, RMSDiff> pm(imSize);
-        loadSnapshots(pm);
+        trainRoute(pm);
 
         // Time testing phase
         Timer<> t{ "Time taken for testing: " };
@@ -67,7 +67,7 @@ main()
         constexpr size_t numComp = 3;
         std::cout << std::endl <<  "Testing with " << numComp << " weighted snapshots..." << std::endl;
         PerfectMemory<WeightSnapshotsDynamic<numComp>> pm(imSize);
-        loadSnapshots(pm);
+        trainRoute(pm);
 
         Timer<> t{ "Time taken for testing: " };
 
@@ -87,7 +87,7 @@ main()
         std::cout << std::endl << "Testing with HOG..." << std::endl;
 
         PerfectMemoryHOG<> pm(imSize);
-        loadSnapshots(pm);
+        trainRoute(pm);
 
         // Time testing phase
         Timer<> t{ "Time taken for testing: " };

--- a/examples/perfect_memory/perfect_memory_test.cc
+++ b/examples/perfect_memory/perfect_memory_test.cc
@@ -47,7 +47,7 @@ main()
 
     {
         std::cout << std::endl << "Testing with RMS image difference..." << std::endl;
-        PerfectMemory<BestMatchingSnapshot, RMSDiff> pm(imSize);
+        PerfectMemory<BestMatchingSnapshot, InSilicoRotater, RMSDiff> pm(imSize);
         trainRoute(pm);
 
         // Time testing phase

--- a/examples/perfect_memory/plot_ridf.cc
+++ b/examples/perfect_memory/plot_ridf.cc
@@ -1,26 +1,18 @@
-// Standard C includes
-#include <cmath>
-
 // Standard C++ includes
-#include <algorithm>
 #include <iostream>
 
 // BoB robotics includes
 #include "navigation/perfect_memory.h"
+#include "navigation/plot.h"
 
-// Third-party includes
-#include "third_party/matplotlibcpp.h"
-
-namespace plt = matplotlibcpp;
-
-using namespace BoBRobotics;
+using namespace BoBRobotics::Navigation;
 
 int
 main()
 {
     // Class to run perfect memory algorithm
     cv::Size imSize(180, 50);
-    Navigation::PerfectMemory<> pm(imSize);
+    PerfectMemory<> pm(imSize);
 
     // Load a single snapshot
     cv::Mat snap = cv::imread("../../tools/ant_world_db_creator/ant1_route1/image_00010.png", CV_LOAD_IMAGE_GRAYSCALE);
@@ -28,30 +20,8 @@ main()
     pm.train(snap);
 
     // Compare snapshot with itself
-    std::vector<float> ridf = pm.getImageDifferences(snap)[0];
-
-    // Rotate so the range is from -180 to 180 deg
-    std::rotate(ridf.begin(), ridf.begin() + ceil((double) ridf.size() / 2.0), ridf.end());
-
-    // Normalise values so they are between 0 and 1
-    for (float &f : ridf) {
-        f /= 255.0f;
-    }
-
-    // Copy value from -180 deg to 180 deg
-    ridf.push_back(ridf[0]);
-
-    // Calculate x values (angles)
-    std::vector<float> x(ridf.size());
-    for (size_t i = 0; i < x.size(); i++) {
-        x[i] = -180.0f + (float) i * 360.0f / (x.size() - 1);
-    }
+    std::vector<float> differences = pm.getImageDifferences(snap)[0];
 
     // Plot RIDF
-    plt::plot(x, ridf);
-    plt::ylabel("Image difference");
-    plt::xlabel("Angle (deg)");
-    plt::xlim(-180, 180);
-    plt::ylim(0.0, plt::ylim()[1]);
-    plt::show();
+    plotRIDF(differences);
 }

--- a/navigation/antworld_rotater.h
+++ b/navigation/antworld_rotater.h
@@ -1,0 +1,71 @@
+#pragma once
+
+// BoB robotics includes
+#include "../common/timer.h"
+#include "../libantworld/agent.h"
+
+// Third-party includes
+#include "../third_party/units.h"
+
+namespace BoBRobotics {
+namespace Navigation {
+using namespace units::angle;
+using namespace units::length;
+using namespace units::literals;
+
+//------------------------------------------------------------------------
+// BoBRobotics::Navigation::AntWorldRotater
+//------------------------------------------------------------------------
+class AntWorldRotater
+{
+public:
+    AntWorldRotater(const cv::Size &, AntWorld::AntAgent &agent, const degree_t yawStep = 1_deg, const degree_t pitch = 0_deg, const degree_t roll = 0_deg)
+      : m_Agent(agent)
+      , m_YawStep(yawStep)
+      , m_Pitch(pitch)
+      , m_Roll(roll)
+    {
+        loadImage();
+    }
+
+    cv::Mat &getImage()
+    {
+        return m_Frame;
+    }
+
+    bool next()
+    {
+        m_CurrentYaw += m_YawStep;
+        if (m_CurrentYaw >= 360_deg) {
+            return false;
+        }
+
+        loadImage();
+        return true;
+    }
+
+    size_t count() const
+    {
+        return m_CurrentYaw / m_YawStep;
+    }
+
+    size_t max() const
+    {
+        return 360_deg / m_YawStep;
+    }
+
+private:
+    AntWorld::AntAgent &m_Agent;
+    const degree_t m_YawStep, m_Pitch, m_Roll;
+    degree_t m_CurrentYaw = 0_deg;
+    cv::Mat m_FrameRGB, m_Frame;
+
+    void loadImage()
+    {
+        m_Agent.setAttitude(m_CurrentYaw, m_Pitch, m_Roll);
+        m_Agent.readFrame(m_FrameRGB);
+        cv::cvtColor(m_FrameRGB, m_Frame, CV_BGR2GRAY);
+    }
+}; // AntWorldRotater
+} // Navigation
+} // BoBRobotics

--- a/navigation/antworld_rotater.h
+++ b/navigation/antworld_rotater.h
@@ -17,6 +17,10 @@ using namespace units::literals;
 //------------------------------------------------------------------------
 // BoBRobotics::Navigation::AntWorldRotater
 //------------------------------------------------------------------------
+/*!
+ * \brief A "rotater" for PerfectMemoryBase classes which uses OpenGL to rotate
+ *        in AntWorld
+ */
 class AntWorldRotater
 {
 public:

--- a/navigation/antworld_rotater.h
+++ b/navigation/antworld_rotater.h
@@ -42,7 +42,7 @@ public:
     }
 
     template<class Func>
-    void operator()(Func func)
+    void rotate(Func func)
     {
         cv::Mat fr, mask;
         size_t i = 0;

--- a/navigation/antworld_rotater.h
+++ b/navigation/antworld_rotater.h
@@ -39,34 +39,18 @@ public:
 
         // This rotater doesn't support mask images
         assert(maskImage.empty());
-
-        loadImage();
     }
 
-    cv::Mat &getImage()
+    template<class Func>
+    void operator()(Func func)
     {
-        return m_Frame;
-    }
-
-    cv::Mat getMaskImage()
-    {
-        return cv::Mat();
-    }
-
-    bool next()
-    {
-        m_CurrentYaw += m_YawStep;
-        if (m_CurrentYaw >= 360_deg) {
-            return false;
+        cv::Mat fr, mask;
+        size_t i = 0;
+        for (degree_t yaw = 0_deg; yaw < 360_deg; yaw += m_YawStep, i++) {
+            m_Agent.setAttitude(yaw, m_Pitch, m_Roll);
+            m_Agent.readGreyscaleFrame(fr);
+            func(fr, mask, i);
         }
-
-        loadImage();
-        return true;
-    }
-
-    size_t count() const
-    {
-        return m_CurrentYaw / m_YawStep;
     }
 
     size_t max() const
@@ -77,14 +61,6 @@ public:
 private:
     AntWorld::AntAgent &m_Agent;
     const degree_t m_YawStep, m_Pitch, m_Roll;
-    degree_t m_CurrentYaw = 0_deg;
-    cv::Mat m_Frame;
-
-    void loadImage()
-    {
-        m_Agent.setAttitude(m_CurrentYaw, m_Pitch, m_Roll);
-        m_Agent.readGreyscaleFrame(m_Frame);
-    }
 }; // AntWorldRotater
 } // Navigation
 } // BoBRobotics

--- a/navigation/antworld_rotater.h
+++ b/navigation/antworld_rotater.h
@@ -1,16 +1,17 @@
 #pragma once
 
-// BoB robotics includes
-#include "../common/timer.h"
-#include "../libantworld/agent.h"
+// Standard C includes
+#include <cassert>
 
 // Third-party includes
 #include "../third_party/units.h"
 
+// BoB robotics includes
+#include "../libantworld/agent.h"
+
 namespace BoBRobotics {
 namespace Navigation {
 using namespace units::angle;
-using namespace units::length;
 using namespace units::literals;
 
 //------------------------------------------------------------------------
@@ -19,12 +20,17 @@ using namespace units::literals;
 class AntWorldRotater
 {
 public:
-    AntWorldRotater(const cv::Size &, AntWorld::AntAgent &agent, const degree_t yawStep = 1_deg, const degree_t pitch = 0_deg, const degree_t roll = 0_deg)
+    AntWorldRotater(const cv::Size &unwrapRes,
+                    AntWorld::AntAgent &agent,
+                    const degree_t yawStep = 1_deg,
+                    const degree_t pitch = 0_deg,
+                    const degree_t roll = 0_deg)
       : m_Agent(agent)
       , m_YawStep(yawStep)
       , m_Pitch(pitch)
       , m_Roll(roll)
     {
+        assert(agent.getOutputSize() == unwrapRes);
         loadImage();
     }
 

--- a/navigation/antworld_rotater.h
+++ b/navigation/antworld_rotater.h
@@ -58,13 +58,12 @@ private:
     AntWorld::AntAgent &m_Agent;
     const degree_t m_YawStep, m_Pitch, m_Roll;
     degree_t m_CurrentYaw = 0_deg;
-    cv::Mat m_FrameRGB, m_Frame;
+    cv::Mat m_Frame;
 
     void loadImage()
     {
         m_Agent.setAttitude(m_CurrentYaw, m_Pitch, m_Roll);
-        m_Agent.readFrame(m_FrameRGB);
-        cv::cvtColor(m_FrameRGB, m_Frame, CV_BGR2GRAY);
+        m_Agent.readGreyscaleFrame(m_Frame);
     }
 }; // AntWorldRotater
 } // Navigation

--- a/navigation/antworld_rotater.h
+++ b/navigation/antworld_rotater.h
@@ -21,6 +21,7 @@ class AntWorldRotater
 {
 public:
     AntWorldRotater(const cv::Size &unwrapRes,
+                    const cv::Mat &maskImage,
                     AntWorld::AntAgent &agent,
                     const degree_t yawStep = 1_deg,
                     const degree_t pitch = 0_deg,
@@ -31,12 +32,21 @@ public:
       , m_Roll(roll)
     {
         assert(agent.getOutputSize() == unwrapRes);
+
+        // This rotater doesn't support mask images
+        assert(maskImage.empty());
+
         loadImage();
     }
 
     cv::Mat &getImage()
     {
         return m_Frame;
+    }
+
+    cv::Mat getMaskImage()
+    {
+        return cv::Mat();
     }
 
     bool next()

--- a/navigation/insilico_rotater.h
+++ b/navigation/insilico_rotater.h
@@ -31,7 +31,7 @@ public:
     }
 
     template<class Func>
-    void operator()(Func func)
+    void rotate(Func func)
     {
         size_t i = 0;
         while (true) {

--- a/navigation/insilico_rotater.h
+++ b/navigation/insilico_rotater.h
@@ -9,6 +9,7 @@ class InSilicoRotater
 {
 public:
     InSilicoRotater(const cv::Size &unwrapRes,
+                    const cv::Mat &maskImage,
                     const cv::Mat &image,
                     const unsigned int scanStep = 1)
       : m_CurrentRotation(0)
@@ -19,11 +20,17 @@ public:
         assert(image.type() == CV_8UC1);
 
         image.copyTo(m_ScratchImage);
+        maskImage.copyTo(m_ScratchMaskImage);
     }
 
     cv::Mat &getImage()
     {
         return m_ScratchImage;
+    }
+
+    cv::Mat &getMaskImage()
+    {
+        return m_ScratchMaskImage;
     }
 
     bool next()
@@ -33,13 +40,9 @@ public:
             return false;
         }
 
-        // Loop through rows
-        for (int y = 0; y < m_ScratchImage.rows; y++) {
-            // Get pointer to start of row
-            uint8_t *rowPtr = m_ScratchImage.ptr(y);
-
-            // Rotate row to left by m_ScanStep pixels
-            std::rotate(rowPtr, rowPtr + m_ScanStep, rowPtr + m_ScratchImage.cols);
+        rollImage(m_ScratchImage);
+        if (!m_ScratchMaskImage.empty()) {
+            rollImage(m_ScratchMaskImage);
         }
         m_CurrentRotation = next;
 
@@ -59,7 +62,19 @@ public:
 private:
     int m_CurrentRotation;
     const unsigned int m_ScanStep;
-    cv::Mat m_ScratchImage;
+    cv::Mat m_ScratchImage, m_ScratchMaskImage;
+
+    void rollImage(cv::Mat &image)
+    {
+        // Loop through rows
+        for (int y = 0; y < image.rows; y++) {
+            // Get pointer to start of row
+            uint8_t *rowPtr = image.ptr(y);
+
+            // Rotate row to left by m_ScanStep pixels
+            std::rotate(rowPtr, rowPtr + m_ScanStep, rowPtr + image.cols);
+        }
+    }
 };
 } // Navigation
 } // BoBRobotics

--- a/navigation/insilico_rotater.h
+++ b/navigation/insilico_rotater.h
@@ -1,0 +1,65 @@
+#pragma once
+
+// OpenCV
+#include <opencv2/opencv.hpp>
+
+namespace BoBRobotics {
+namespace Navigation {
+class InSilicoRotater
+{
+public:
+    InSilicoRotater(const cv::Size &unwrapRes,
+                    const cv::Mat &image,
+                    const unsigned int scanStep = 1)
+      : m_CurrentRotation(0)
+      , m_ScanStep(scanStep)
+    {
+        assert(image.cols == unwrapRes.width);
+        assert(image.rows == unwrapRes.height);
+        assert(image.type() == CV_8UC1);
+
+        image.copyTo(m_ScratchImage);
+    }
+
+    cv::Mat &getImage()
+    {
+        return m_ScratchImage;
+    }
+
+    bool next()
+    {
+        int next = m_CurrentRotation + m_ScanStep;
+        if (next >= m_ScratchImage.cols) {
+            return false;
+        }
+
+        // Loop through rows
+        for (int y = 0; y < m_ScratchImage.rows; y++) {
+            // Get pointer to start of row
+            uint8_t *rowPtr = m_ScratchImage.ptr(y);
+
+            // Rotate row to left by m_ScanStep pixels
+            std::rotate(rowPtr, rowPtr + m_ScanStep, rowPtr + m_ScratchImage.cols);
+        }
+        m_CurrentRotation = next;
+
+        return true;
+    }
+
+    size_t count() const
+    {
+        return m_CurrentRotation / m_ScanStep;
+    }
+
+    size_t max() const
+    {
+        return m_ScratchImage.cols / m_ScanStep;
+    }
+
+private:
+    int m_CurrentRotation;
+    const unsigned int m_ScanStep;
+    cv::Mat m_ScratchImage;
+};
+} // Navigation
+} // BoBRobotics

--- a/navigation/insilico_rotater.h
+++ b/navigation/insilico_rotater.h
@@ -5,6 +5,14 @@
 
 namespace BoBRobotics {
 namespace Navigation {
+//------------------------------------------------------------------------
+// BoBRobotics::Navigation::InSilicoRotater
+//------------------------------------------------------------------------
+/*!
+ * \brief A "rotater" for PerfectMemoryBase classes which rotates a panoramic
+ *        image by moving columns of pixels from one side of the image to the
+ *        other
+ */
 class InSilicoRotater
 {
 public:

--- a/navigation/perfect_memory.h
+++ b/navigation/perfect_memory.h
@@ -38,8 +38,8 @@ class PerfectMemory
   : public PerfectMemoryBase<RIDFProcessor, Rotater>
 {
 public:
-    PerfectMemory(const cv::Size unwrapRes, const unsigned int scanStep = 1, const filesystem::path outputPath = "snapshots")
-      : PerfectMemoryBase<RIDFProcessor, Rotater>(unwrapRes, scanStep, outputPath)
+    PerfectMemory(const cv::Size unwrapRes, const unsigned int scanStep = 1)
+      : PerfectMemoryBase<RIDFProcessor, Rotater>(unwrapRes, scanStep)
       , m_Differencer(unwrapRes.width * unwrapRes.height)
       , m_DiffScratchImage(unwrapRes, CV_8UC1)
     {}

--- a/navigation/perfect_memory.h
+++ b/navigation/perfect_memory.h
@@ -31,13 +31,15 @@ namespace Navigation {
  * \tparam RIDFProcessor The method used to calculate the heading (e.g. single snapshot v. multi-snapshot)
  * \tparam Differencer This can be AbsDiff or RMSDiff
  */
-template<typename RIDFProcessor = BestMatchingSnapshot, typename Differencer = AbsDiff>
+template<typename RIDFProcessor = BestMatchingSnapshot,
+         typename Differencer = AbsDiff,
+         typename Rotater = InSilicoRotater>
 class PerfectMemory
-  : public PerfectMemoryBase<RIDFProcessor>
+  : public PerfectMemoryBase<RIDFProcessor, Rotater>
 {
 public:
     PerfectMemory(const cv::Size unwrapRes, const unsigned int scanStep = 1, const filesystem::path outputPath = "snapshots")
-      : PerfectMemoryBase<RIDFProcessor>(unwrapRes, scanStep, outputPath)
+      : PerfectMemoryBase<RIDFProcessor, Rotater>(unwrapRes, scanStep, outputPath)
       , m_Differencer(unwrapRes.width * unwrapRes.height)
       , m_DiffScratchImage(unwrapRes, CV_8UC1)
     {}
@@ -90,7 +92,7 @@ protected:
             float sumDifference = 0.0f;
             unsigned int numUnmaskedPixels = 0;
             const uint8_t *end = &imageMaskPtr[imSize];
-            while(imageMaskPtr < end) {
+            while (imageMaskPtr < end) {
                 // If this pixel is masked by neither of the masks
                 if (*imageMaskPtr++ != 0 && *snapshotMaskPtr++) {
                     // Accumulate sum of differences

--- a/navigation/perfect_memory.h
+++ b/navigation/perfect_memory.h
@@ -38,8 +38,8 @@ class PerfectMemory
   : public PerfectMemoryBase<RIDFProcessor, Rotater>
 {
 public:
-    PerfectMemory(const cv::Size unwrapRes, const unsigned int scanStep = 1)
-      : PerfectMemoryBase<RIDFProcessor, Rotater>(unwrapRes, scanStep)
+    PerfectMemory(const cv::Size unwrapRes)
+      : PerfectMemoryBase<RIDFProcessor, Rotater>(unwrapRes)
       , m_Differencer(unwrapRes.width * unwrapRes.height)
       , m_DiffScratchImage(unwrapRes, CV_8UC1)
     {}

--- a/navigation/perfect_memory.h
+++ b/navigation/perfect_memory.h
@@ -29,6 +29,7 @@ namespace Navigation {
  * \brief The conventional perfect memory (RIDF) algorithm
  *
  * \tparam RIDFProcessor The method used to calculate the heading (e.g. single snapshot v. multi-snapshot)
+ * \tparam Rotater Method used to rotate current view (e.g. InSilicoRotater or AntWorldRotater)
  * \tparam Differencer This can be AbsDiff or RMSDiff
  */
 template<typename RIDFProcessor = BestMatchingSnapshot,

--- a/navigation/perfect_memory.h
+++ b/navigation/perfect_memory.h
@@ -32,8 +32,8 @@ namespace Navigation {
  * \tparam Differencer This can be AbsDiff or RMSDiff
  */
 template<typename RIDFProcessor = BestMatchingSnapshot,
-         typename Differencer = AbsDiff,
-         typename Rotater = InSilicoRotater>
+         typename Rotater = InSilicoRotater,
+         typename Differencer = AbsDiff>
 class PerfectMemory
   : public PerfectMemoryBase<RIDFProcessor, Rotater>
 {

--- a/navigation/perfect_memory_base.h
+++ b/navigation/perfect_memory_base.h
@@ -77,13 +77,12 @@ public:
      * angles.
      */
     template<class... Ts>
-    std::vector<std::vector<float>> getImageDifferences(Ts&&... args) const
+    std::vector<std::vector<float>> getImageDifferences(Ts &&... args) const
     {
         const size_t numSnapshots = getNumSnapshots();
         assert(numSnapshots > 0);
 
-        Rotater rotater(getUnwrapResolution(), getMaskImage(),
-                        std::forward<Ts>(args)...);
+        Rotater rotater(getUnwrapResolution(), getMaskImage(), std::forward<Ts>(args)...);
 
         // Create vector to store RIDF values
         std::vector<std::vector<float>> differences(numSnapshots);
@@ -92,16 +91,14 @@ public:
         }
 
         // Scan across image columns
-        do {
+        rotater([this, &differences, numSnapshots](const cv::Mat &fr, const cv::Mat &mask, size_t i) {
             // Loop through snapshots
             for (size_t s = 0; s < numSnapshots; s++) {
                 // Calculate difference
-                const auto diff = calcSnapshotDifference(rotater.getImage(),
-                                                         rotater.getMaskImage(),
-                                                         s);
-                differences[s][rotater.count()] = diff;
+                const auto diff = calcSnapshotDifference(fr, mask, s);
+                differences[s][i] = diff;
             }
-        } while (rotater.next());
+        });
 
         return differences;
     }
@@ -116,7 +113,7 @@ public:
      * angles.
      */
     template<class... Ts>
-    auto getHeading(Ts&&... args) const
+    auto getHeading(Ts &&... args) const
     {
         auto differences = getImageDifferences(std::forward<Ts>(args)...);
         const size_t numSnapshots = getNumSnapshots();

--- a/navigation/perfect_memory_base.h
+++ b/navigation/perfect_memory_base.h
@@ -68,7 +68,14 @@ public:
         addSnapshot(image);
     }
 
-    //! Get differences between image and stored snapshots
+    /*!
+     * \brief Get differences between current view and stored snapshots
+     *
+     * The parameters are perfect-forwarded to the Rotater class, so e.g. for
+     * InSilicoRotater one passes in a cv::Mat and (optionally) an unsigned int
+     * for the scan step and for the AntWorldRotater, one passes in one or more
+     * angles.
+     */
     template<class... Ts>
     std::vector<std::vector<float>> getImageDifferences(Ts&&... args) const
     {
@@ -99,7 +106,15 @@ public:
         return differences;
     }
 
-    //! Get an estimate for heading based on comparing image with stored snapshots
+    /*!
+     * \brief Get an estimate for heading based on comparing image with stored
+     *        snapshots
+     *
+     * The parameters are perfect-forwarded to the Rotater class, so e.g. for
+     * InSilicoRotater one passes in a cv::Mat and (optionally) an unsigned int
+     * for the scan step and for the AntWorldRotater, one passes in one or more
+     * angles.
+     */
     template<class... Ts>
     auto getHeading(Ts&&... args) const
     {

--- a/navigation/perfect_memory_base.h
+++ b/navigation/perfect_memory_base.h
@@ -77,7 +77,7 @@ public:
      * angles.
      */
     template<class... Ts>
-    std::vector<std::vector<float>> getImageDifferences(Ts &&... args) const
+    const std::vector<std::vector<float>> &getImageDifferences(Ts &&... args) const
     {
         calcImageDifferences(std::forward<Ts>(args)...);
         return m_Differences;

--- a/navigation/perfect_memory_base.h
+++ b/navigation/perfect_memory_base.h
@@ -16,13 +16,14 @@
 // OpenCV
 #include <opencv2/opencv.hpp>
 
-// BoB robotics includes
-#include "../common/image_database.h"
-
 // Third-party includes
 #include "../third_party/units.h"
 
+// BoB robotics includes
+#include "../common/image_database.h"
+
 // Local includes
+#include "insilico_rotater.h"
 #include "visual_navigation_base.h"
 
 namespace BoBRobotics {
@@ -30,61 +31,6 @@ namespace Navigation {
 using namespace units::angle;
 using namespace units::dimensionless;
 using namespace units::literals;
-
-class InSilicoRotater
-{
-public:
-    InSilicoRotater(const cv::Size &unwrapRes, const cv::Mat &image, const unsigned int scanStep = 1)
-      : m_CurrentRotation(0)
-      , m_ScanStep(scanStep)
-    {
-        assert(image.cols == unwrapRes.width);
-        assert(image.rows == unwrapRes.height);
-        assert(image.type() == CV_8UC1);
-
-        image.copyTo(m_ScratchImage);
-    }
-
-    cv::Mat &getImage()
-    {
-        return m_ScratchImage;
-    }
-
-    bool next()
-    {
-        int next = m_CurrentRotation + m_ScanStep;
-        if (next >= m_ScratchImage.cols) {
-            return false;
-        }
-
-        // Loop through rows
-        for (int y = 0; y < m_ScratchImage.rows; y++) {
-            // Get pointer to start of row
-            uint8_t *rowPtr = m_ScratchImage.ptr(y);
-
-            // Rotate row to left by m_ScanStep pixels
-            std::rotate(rowPtr, rowPtr + m_ScanStep, rowPtr + m_ScratchImage.cols);
-        }
-        m_CurrentRotation = next;
-
-        return true;
-    }
-
-    size_t count() const
-    {
-        return m_CurrentRotation / m_ScanStep;
-    }
-
-    size_t max() const
-    {
-        return m_ScratchImage.cols / m_ScanStep;
-    }
-
-private:
-    int m_CurrentRotation;
-    const unsigned int m_ScanStep;
-    cv::Mat m_ScratchImage;
-};
 
 //------------------------------------------------------------------------
 // BoBRobotics::Navigation::PerfectMemoryBase

--- a/navigation/perfect_memory_base.h
+++ b/navigation/perfect_memory_base.h
@@ -91,7 +91,7 @@ public:
         }
 
         // Scan across image columns
-        rotater(
+        rotater.rotate(
             [this, &differences, numSnapshots](const cv::Mat &fr, const cv::Mat &mask, size_t i)
             {
                 // Loop through snapshots

--- a/navigation/perfect_memory_base.h
+++ b/navigation/perfect_memory_base.h
@@ -91,14 +91,16 @@ public:
         }
 
         // Scan across image columns
-        rotater([this, &differences, numSnapshots](const cv::Mat &fr, const cv::Mat &mask, size_t i) {
-            // Loop through snapshots
-            for (size_t s = 0; s < numSnapshots; s++) {
-                // Calculate difference
-                const auto diff = calcSnapshotDifference(fr, mask, s);
-                differences[s][i] = diff;
-            }
-        });
+        rotater(
+            [this, &differences, numSnapshots](const cv::Mat &fr, const cv::Mat &mask, size_t i)
+            {
+                // Loop through snapshots
+                for (size_t s = 0; s < numSnapshots; s++) {
+                    // Calculate difference
+                    const auto diff = calcSnapshotDifference(fr, mask, s);
+                    differences[s][i] = diff;
+                }
+            });
 
         return differences;
     }

--- a/navigation/perfect_memory_base.h
+++ b/navigation/perfect_memory_base.h
@@ -91,9 +91,8 @@ class PerfectMemoryBase
   : public VisualNavigationBase
 {
 public:
-    PerfectMemoryBase(const cv::Size unwrapRes, const unsigned int scanStep = 1,
-                      const filesystem::path outputPath = "snapshots")
-      : VisualNavigationBase(unwrapRes, scanStep, outputPath)
+    PerfectMemoryBase(const cv::Size unwrapRes, const unsigned int scanStep = 1)
+      : VisualNavigationBase(unwrapRes, scanStep)
     {}
 
     //------------------------------------------------------------------------
@@ -108,7 +107,7 @@ public:
     //------------------------------------------------------------------------
     // Public API
     //------------------------------------------------------------------------
-    virtual void train(const cv::Mat &image, bool saveImage = false) override
+    virtual void train(const cv::Mat &image) override
     {
         const auto &unwrapRes = getUnwrapResolution();
         assert(image.cols == unwrapRes.width);
@@ -116,12 +115,7 @@ public:
         assert(image.type() == CV_8UC1);
 
         // Add snapshot
-        const size_t index = addSnapshot(image);
-
-        // Write image to disk, if desired
-        if (saveImage) {
-            saveSnapshot(index, image);
-        }
+        addSnapshot(image);
     }
 
     //! Get differences between image and stored snapshots
@@ -190,15 +184,6 @@ protected:
 
     //! Calculate difference between memory and snapshot with index
     virtual float calcSnapshotDifference(const cv::Mat &image, const cv::Mat &imageMask, size_t snapshot) const = 0;
-
-private:
-    //------------------------------------------------------------------------
-    // Private methods
-    //------------------------------------------------------------------------
-    filesystem::path getSnapshotPath(size_t index) const
-    {
-        return getSnapshotsPath() / getRouteDatabaseFilename(index);
-    }
 
     //------------------------------------------------------------------------
     // Members

--- a/navigation/perfect_memory_base.h
+++ b/navigation/perfect_memory_base.h
@@ -75,7 +75,8 @@ public:
         const size_t numSnapshots = getNumSnapshots();
         assert(numSnapshots > 0);
 
-        Rotater rotater(getUnwrapResolution(), std::forward<Ts>(args)...);
+        Rotater rotater(getUnwrapResolution(), getMaskImage(),
+                        std::forward<Ts>(args)...);
 
         // Create vector to store RIDF values
         std::vector<std::vector<float>> differences(numSnapshots);
@@ -88,14 +89,11 @@ public:
             // Loop through snapshots
             for (size_t s = 0; s < numSnapshots; s++) {
                 // Calculate difference
-                const auto diff = calcSnapshotDifference(rotater.getImage(), m_ScratchMaskImage, s);
+                const auto diff = calcSnapshotDifference(rotater.getImage(),
+                                                         rotater.getMaskImage(),
+                                                         s);
                 differences[s][rotater.count()] = diff;
             }
-
-            // **TODO**: Add this feature back in!
-            // if (!m_ScratchMaskImage.empty()) {
-            //     rollImage(m_ScratchMaskImage);
-            // }
         } while (rotater.next());
 
         return differences;
@@ -131,11 +129,6 @@ protected:
 
     //! Calculate difference between memory and snapshot with index
     virtual float calcSnapshotDifference(const cv::Mat &image, const cv::Mat &imageMask, size_t snapshot) const = 0;
-
-    //------------------------------------------------------------------------
-    // Members
-    //------------------------------------------------------------------------
-    mutable cv::Mat m_ScratchMaskImage;
 }; // PerfectMemoryBase
 } // Navigation
 } // BoBRobotics

--- a/navigation/perfect_memory_base.h
+++ b/navigation/perfect_memory_base.h
@@ -8,6 +8,7 @@
 #include <algorithm>
 #include <array>
 #include <iostream>
+#include <functional>
 #include <limits>
 #include <numeric>
 #include <tuple>

--- a/navigation/perfect_memory_hog.h
+++ b/navigation/perfect_memory_hog.h
@@ -24,8 +24,8 @@ namespace Navigation {
 //------------------------------------------------------------------------
 //! Perfect memory algorithm using HOG features instead of raw image matching
 template<typename RIDFProcessor = BestMatchingSnapshot,
-         typename Differencer = AbsDiff,
-         typename Rotater = InSilicoRotater>
+         typename Rotater = InSilicoRotater,
+         typename Differencer = AbsDiff>
 class PerfectMemoryHOG : public PerfectMemoryBase<RIDFProcessor, Rotater>
 {
 public:

--- a/navigation/perfect_memory_hog.h
+++ b/navigation/perfect_memory_hog.h
@@ -24,14 +24,15 @@ namespace Navigation {
 //------------------------------------------------------------------------
 //! Perfect memory algorithm using HOG features instead of raw image matching
 template<typename RIDFProcessor = BestMatchingSnapshot,
-         typename Differencer = AbsDiff>
-class PerfectMemoryHOG : public PerfectMemoryBase<RIDFProcessor>
+         typename Differencer = AbsDiff,
+         typename Rotater = InSilicoRotater>
+class PerfectMemoryHOG : public PerfectMemoryBase<RIDFProcessor, Rotater>
 {
 public:
     PerfectMemoryHOG(const cv::Size unwrapRes, const unsigned int scanStep = 1,
                      const filesystem::path outputPath = "snapshots",
                      const int HOGPixelsPerCell = 10, int HOGOrientations = 8)
-      : PerfectMemoryBase<RIDFProcessor>(unwrapRes, scanStep, outputPath)
+      : PerfectMemoryBase<RIDFProcessor, Rotater>(unwrapRes, scanStep, outputPath)
       , m_HOGDescriptorSize(unwrapRes.width * unwrapRes.height *
                             HOGOrientations / (HOGPixelsPerCell * HOGPixelsPerCell))
       , m_Differencer(m_HOGDescriptorSize)

--- a/navigation/perfect_memory_hog.h
+++ b/navigation/perfect_memory_hog.h
@@ -30,10 +30,9 @@ class PerfectMemoryHOG : public PerfectMemoryBase<RIDFProcessor, Rotater>
 {
 public:
     PerfectMemoryHOG(const cv::Size unwrapRes,
-                     const unsigned int scanStep = 1,
                      const int HOGPixelsPerCell = 10,
                      int HOGOrientations = 8)
-      : PerfectMemoryBase<RIDFProcessor, Rotater>(unwrapRes, scanStep)
+      : PerfectMemoryBase<RIDFProcessor, Rotater>(unwrapRes)
       , m_HOGDescriptorSize(unwrapRes.width * unwrapRes.height *
                             HOGOrientations / (HOGPixelsPerCell * HOGPixelsPerCell))
       , m_Differencer(m_HOGDescriptorSize)

--- a/navigation/perfect_memory_hog.h
+++ b/navigation/perfect_memory_hog.h
@@ -29,10 +29,11 @@ template<typename RIDFProcessor = BestMatchingSnapshot,
 class PerfectMemoryHOG : public PerfectMemoryBase<RIDFProcessor, Rotater>
 {
 public:
-    PerfectMemoryHOG(const cv::Size unwrapRes, const unsigned int scanStep = 1,
-                     const filesystem::path outputPath = "snapshots",
-                     const int HOGPixelsPerCell = 10, int HOGOrientations = 8)
-      : PerfectMemoryBase<RIDFProcessor, Rotater>(unwrapRes, scanStep, outputPath)
+    PerfectMemoryHOG(const cv::Size unwrapRes,
+                     const unsigned int scanStep = 1,
+                     const int HOGPixelsPerCell = 10,
+                     int HOGOrientations = 8)
+      : PerfectMemoryBase<RIDFProcessor, Rotater>(unwrapRes, scanStep)
       , m_HOGDescriptorSize(unwrapRes.width * unwrapRes.height *
                             HOGOrientations / (HOGPixelsPerCell * HOGPixelsPerCell))
       , m_Differencer(m_HOGDescriptorSize)

--- a/navigation/plot.h
+++ b/navigation/plot.h
@@ -1,0 +1,49 @@
+#pragma once
+
+// Standard C++ includes
+#include <algorithm>
+#include <vector>
+
+// Third-party includes
+#include "third_party/matplotlibcpp.h"
+
+namespace BoBRobotics {
+namespace Navigation {
+
+//! Plot a line graph of a single RIDF
+void
+plotRIDF(const std::vector<float> &differences)
+{
+    // Vector to store modified RIDF
+    std::vector<float> ridf(differences.size() + 1);
+
+    // Rotate so data is in range -180 to 180
+    std::rotate_copy(differences.begin(),
+                     differences.begin() + ceil((float) differences.size() / 2.0f),
+                     differences.end(),
+                     ridf.begin());
+
+    // Normalise to be between 0 and 1
+    for (auto &d : ridf) {
+        d /= 255.0f;
+    }
+
+    // Copy value from -180 to 180 so RIDF is symmetrical
+    ridf.back() = ridf[0];
+
+    // Calculate x values (angles)
+    std::vector<float> x(ridf.size());
+    for (size_t i = 0; i < x.size(); i++) {
+        x[i] = -180.0f + (float) i * 360.0f / (x.size() - 1);
+    }
+
+    // Plot RIDF
+    matplotlibcpp::plot(x, ridf);
+    matplotlibcpp::ylabel("Image difference");
+    matplotlibcpp::xlabel("Angle (deg)");
+    matplotlibcpp::xlim(-180, 180);
+    matplotlibcpp::ylim(0.0, matplotlibcpp::ylim()[1]);
+    matplotlibcpp::show();
+}
+} // Navigation
+} // BoBRobotics

--- a/navigation/plot.h
+++ b/navigation/plot.h
@@ -15,13 +15,14 @@ void
 plotRIDF(const std::vector<float> &differences)
 {
     // Vector to store modified RIDF
-    std::vector<float> ridf(differences.size() + 1);
+    std::vector<float> ridf;
+    ridf.reserve(differences.size() + 1);
 
     // Rotate so data is in range -180 to 180
     std::rotate_copy(differences.begin(),
                      differences.begin() + ceil((float) differences.size() / 2.0f),
                      differences.end(),
-                     ridf.begin());
+                     std::back_inserter(ridf));
 
     // Normalise to be between 0 and 1
     for (auto &d : ridf) {
@@ -29,12 +30,13 @@ plotRIDF(const std::vector<float> &differences)
     }
 
     // Copy value from -180 to 180 so RIDF is symmetrical
-    ridf.back() = ridf[0];
+    ridf.push_back(ridf[0]);
 
     // Calculate x values (angles)
-    std::vector<float> x(ridf.size());
-    for (size_t i = 0; i < x.size(); i++) {
-        x[i] = -180.0f + (float) i * 360.0f / (x.size() - 1);
+    std::vector<float> x;
+    x.reserve(ridf.size());
+    for (size_t i = 0; i < ridf.size(); i++) {
+        x.push_back(-180.0f + (float) i * 360.0f / (ridf.size() - 1));
     }
 
     // Plot RIDF

--- a/navigation/visual_navigation_base.h
+++ b/navigation/visual_navigation_base.h
@@ -27,22 +27,21 @@ namespace Navigation {
 class VisualNavigationBase
 {
 public:
-    VisualNavigationBase(const cv::Size unwrapRes, const unsigned int scanStep,
-                         const filesystem::path outputPath = "snapshots")
+    VisualNavigationBase(const cv::Size unwrapRes, const unsigned int scanStep)
       : m_UnwrapRes(unwrapRes)
       , m_ScanStep(scanStep)
-      , m_SnapshotsPath(outputPath)
     {}
 
     //------------------------------------------------------------------------
     // Declared virtuals
     //------------------------------------------------------------------------
     //! Train the algorithm with the specified image
-    virtual void train(const cv::Mat &image, bool saveImage) = 0;
+    virtual void train(const cv::Mat &image) = 0;
 
     //------------------------------------------------------------------------
     // Public API
     //------------------------------------------------------------------------
+    //! Load single snapshot and train
     void loadSnapshot(const filesystem::path &snapshotPath, bool resizeImage = false)
     {
         if (!snapshotPath.exists()) {
@@ -60,13 +59,7 @@ public:
         }
 
         // Add snapshot
-        train(image, false);
-    }
-
-    //! Load snapshots from default path
-    void loadSnapshots(bool resizeImages = false)
-    {
-        loadSnapshots(m_SnapshotsPath, resizeImages);
+        train(image);
     }
 
     //! Load snapshots from specified path
@@ -86,14 +79,8 @@ public:
         }
     }
 
-    //! Save a snapshot to disk
-    void saveSnapshot(const size_t index, const cv::Mat &image)
-    {
-        cv::imwrite(getSnapshotPath(index).str(), image);
-    }
-
     //! Set mask image (e.g. for masking part of robot)
-    void setMaskImage(const std::string path)
+    void setMaskImage(const std::string &path)
     {
         m_MaskImage = cv::imread(path, cv::IMREAD_GRAYSCALE);
         assert(m_MaskImage.cols == m_UnwrapRes.width);
@@ -119,27 +106,12 @@ public:
         return m_UnwrapRes;
     }
 
-    //! Get output path for snapshots
-    const filesystem::path &getSnapshotsPath() const
-    {
-        return m_SnapshotsPath;
-    }
-
 private:
     //------------------------------------------------------------------------
-    // Private methods
-    //------------------------------------------------------------------------
-    filesystem::path getSnapshotPath(const size_t index) const
-    {
-        return m_SnapshotsPath / getRouteDatabaseFilename(index);
-    }
-
-    //------------------------------------------------------------------------
-    // Members
+    // Private members
     //------------------------------------------------------------------------
     const cv::Size m_UnwrapRes;
     const unsigned int m_ScanStep;
-    const filesystem::path m_SnapshotsPath;
     cv::Mat m_MaskImage;
 }; // PerfectMemoryBase
 } // Navigation

--- a/navigation/visual_navigation_base.h
+++ b/navigation/visual_navigation_base.h
@@ -32,8 +32,6 @@ public:
       : m_UnwrapRes(unwrapRes)
       , m_ScanStep(scanStep)
       , m_SnapshotsPath(outputPath)
-      , m_ScratchMaskImage(unwrapRes, CV_8UC1)
-      , m_ScratchRollImage(unwrapRes, CV_8UC1)
     {}
 
     //------------------------------------------------------------------------
@@ -143,23 +141,6 @@ private:
     const unsigned int m_ScanStep;
     const filesystem::path m_SnapshotsPath;
     cv::Mat m_MaskImage;
-
-    mutable cv::Mat m_ScratchMaskImage;
-    mutable cv::Mat m_ScratchRollImage;
-
-protected:
-    //! 'Rolls' an image to the left
-    void rollImage(cv::Mat &image) const
-    {
-        // Loop through rows
-        for (int y = 0; y < image.rows; y++) {
-            // Get pointer to start of row
-            uint8_t *rowPtr = image.ptr(y);
-
-            // Rotate row to left by m_ScanStep pixels
-            std::rotate(rowPtr, rowPtr + m_ScanStep, rowPtr + image.cols);
-        }
-    }
 }; // PerfectMemoryBase
 } // Navigation
 } // BoBRobotics

--- a/navigation/visual_navigation_base.h
+++ b/navigation/visual_navigation_base.h
@@ -27,9 +27,8 @@ namespace Navigation {
 class VisualNavigationBase
 {
 public:
-    VisualNavigationBase(const cv::Size unwrapRes, const unsigned int scanStep)
+    VisualNavigationBase(const cv::Size unwrapRes)
       : m_UnwrapRes(unwrapRes)
-      , m_ScanStep(scanStep)
     {}
 
     //------------------------------------------------------------------------
@@ -73,12 +72,6 @@ public:
         assert(m_MaskImage.type() == CV_8UC1);
     }
 
-    //! Number of pixels for each scanning "step" when doing RIDF
-    inline unsigned int getScanStep() const
-    {
-        return m_ScanStep;
-    }
-
     //! Return mask image
     const cv::Mat &getMaskImage() const
     {
@@ -96,7 +89,6 @@ private:
     // Private members
     //------------------------------------------------------------------------
     const cv::Size m_UnwrapRes;
-    const unsigned int m_ScanStep;
     cv::Mat m_MaskImage;
 
     bool tryTrain(const filesystem::path &imagePath, bool resizeImage) noexcept


### PR DESCRIPTION
Hi Jamie,

The main change in this PR is that I've added a template argument so one can have an AntAgent rotate on the spot in AntWorld (using OpenGL) as opposed to the usual in-silico image rotation we do. (The tests I've done seem to show that the results aren't massively affected depending on which of these methods we use, but it's good to have the choice.)

I've also made a few, mostly superficial changes to the navigation code but I did also remove the option to save snapshots as one is going along. It made more sense to me to let the user manually save snapshots using the code in image_database.h if desired.

If you're ok with this PR, my next goal was to try to tweak the Ardin/Stone models so they're part of this navigation framework too.