### PR TITLE
doxygen: Don't include whole source files in documentation

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -1029,7 +1029,7 @@ REFERENCES_RELATION    = NO
 # link to the documentation.
 # The default value is: YES.
 
-REFERENCES_LINK_SOURCE = YES
+REFERENCES_LINK_SOURCE = NO
 
 # If SOURCE_TOOLTIPS is enabled (the default) then hovering a hyperlink in the
 # source code will show a tooltip with additional information such as prototype,
@@ -1069,7 +1069,7 @@ USE_HTAGS              = NO
 # See also: Section \class.
 # The default value is: YES.
 
-VERBATIM_HEADERS       = YES
+VERBATIM_HEADERS       = NO
 
 #---------------------------------------------------------------------------
 # Configuration options related to the alphabetical class index


### PR DESCRIPTION
At the moment doxygen is generating HTML versions for *all* of our source code files. It seems like unnecessary bloat to have two copies of all the source code in the repo, plus the code in the documentation might be out of date anyway. Shall we drop it? People can always browse the code on Github.