### PR TITLE
Fix calculation of headings in route_continuous.cc

### DIFF
--- a/libantworld/route_continuous.cc
+++ b/libantworld/route_continuous.cc
@@ -173,7 +173,7 @@ bool RouteContinuous::load(const std::string &filename)
 
         // Add segment heading to array
         m_Headings.push_back(atan2(makeM(segmentStart[1] - segmentEnd[1]),
-                                   makeM(segmentEnd[0] - segmentStart[0])));
+                                   makeM(segmentStart[0] - segmentEnd[0])));
 
         // Calculate segment length and
         const meter_t segmentLength(distance(segmentStart, segmentEnd));


### PR DESCRIPTION
At the moment the calculation seems to give incorrect headings (not sure
exactly why). With this fix the headings look correct and when a route
is displayed on screen the views look sensible too (the agent seems to
face the right way).