### PR TITLE
Vicon plotting and API changes

### DIFF
--- a/common/plot_agent.h
+++ b/common/plot_agent.h
@@ -1,0 +1,28 @@
+#pragma once
+
+// Third-party includes
+#include "../third_party/matplotlibcpp.h"
+#include "../third_party/units.h"
+
+// Standard C++ includes
+#include <array>
+
+namespace BoBRobotics {
+    template<typename AgentType>
+    void plotAgent(const AgentType &agent, std::array<double, 2> &&xlim, std::array<double, 2> &&ylim)
+    {
+        // Update plot
+        const auto position = agent.template getPosition<>();
+        const auto attitude = agent.template getAttitude<>();
+        const std::vector<double> vx{ position[0].value() };
+        const std::vector<double> vy{ position[1].value() };
+        const std::vector<double> vu{ units::math::cos(attitude[0]) };
+        const std::vector<double> vv{ units::math::sin(attitude[0]) };
+        const std::vector<int> x0 { 0 }, y0 { 0 };
+        matplotlibcpp::clf();
+        matplotlibcpp::plot(x0, y0, "r+");
+        matplotlibcpp::quiver(vx, vy, vu, vv);
+        matplotlibcpp::xlim(xlim[0], xlim[1]);
+        matplotlibcpp::ylim(ylim[0], ylim[1]);
+    }
+} // BoBRobotics

--- a/examples/vicon/.gitignore
+++ b/examples/vicon/.gitignore
@@ -1,2 +1,3 @@
 /vicon_test
 /vicon_velocity_test
+/vicon_plot_test

--- a/examples/vicon/Makefile
+++ b/examples/vicon/Makefile
@@ -3,7 +3,7 @@ CXXFLAGS += -I../..
 
 .PHONY: all clean
 
-all: vicon_test vicon_velocity_test
+all: vicon_test vicon_velocity_test vicon_plot_test
 
 -include vicon_test.d
 
@@ -14,6 +14,9 @@ vicon_test: vicon_test.cc vicon_test.d
 
 vicon_velocity_test: vicon_velocity_test.cc vicon_velocity_test.d
 	$(CXX) $(CXXFLAGS) $(LINK_FLAGS) vicon_velocity_test.cc -o vicon_velocity_test
+
+vicon_plot_test:
+	$(MAKE) -f MakefilePlotTest
 
 %.d: ;
 

--- a/examples/vicon/MakefilePlotTest
+++ b/examples/vicon/MakefilePlotTest
@@ -1,0 +1,12 @@
+WITH_MATPLOTLIBCPP := 1
+include ../../common/flags.mk
+CXXFLAGS += -I../..
+
+EXECUTABLE := vicon_plot_test
+
+-include $(EXECUTABLE).d
+
+$(EXECUTABLE): $(EXECUTABLE).cc $(EXECUTABLE).d
+	$(CXX) $(CXXFLAGS) $(LINK_FLAGS) -o $@ $<
+
+%.d: ;

--- a/examples/vicon/MakefilePlotTest
+++ b/examples/vicon/MakefilePlotTest
@@ -7,6 +7,6 @@ EXECUTABLE := vicon_plot_test
 -include $(EXECUTABLE).d
 
 $(EXECUTABLE): $(EXECUTABLE).cc $(EXECUTABLE).d
-	$(CXX) $(CXXFLAGS) $(LINK_FLAGS) -o $@ $<
+	$(CXX) -o $@ $< $(CXXFLAGS) $(LINK_FLAGS)
 
 %.d: ;

--- a/examples/vicon/vicon_plot_test.cc
+++ b/examples/vicon/vicon_plot_test.cc
@@ -6,7 +6,7 @@
 
 // BoB robotics includes
 #include "vicon/capture_control.h"
-#include "vicon/object_data_plotter.h"
+#include "vicon/object_plotter.h"
 #include "vicon/udp.h"
 
 using namespace BoBRobotics::Vicon;
@@ -21,7 +21,7 @@ auto now()
 int
 main()
 {
-    UDPClient<ObjectDataPlotter<>> vicon(51001);
+    UDPClient<ObjectPlotter<>> vicon(51001);
     CaptureControl viconCaptureControl("192.168.1.100", 3003, "c:\\users\\ad374\\Desktop");
     while (vicon.getNumObjects() == 0) {
         std::this_thread::sleep_for(1s);

--- a/examples/vicon/vicon_plot_test.cc
+++ b/examples/vicon/vicon_plot_test.cc
@@ -1,0 +1,35 @@
+// C++ includes
+#include <chrono>
+#include <cstdlib>
+#include <iostream>
+#include <thread>
+
+// BoB robotics includes
+#include "vicon/capture_control.h"
+#include "vicon/object_data_plotter.h"
+#include "vicon/udp.h"
+
+using namespace BoBRobotics::Vicon;
+using namespace std::literals;
+using namespace units::angle;
+
+int
+main()
+{
+    UDPClient<ObjectDataPlotter<>> vicon(51001);
+    CaptureControl viconCaptureControl("192.168.1.100", 3003, "c:\\users\\ad374\\Desktop");
+    while (vicon.getNumObjects() == 0) {
+        std::this_thread::sleep_for(1s);
+        std::cout << "Waiting for object" << std::endl;
+    }
+
+    if (!viconCaptureControl.startRecording("test1")) {
+        return EXIT_FAILURE;
+    }
+    std::this_thread::sleep_for(30s);
+    if (!viconCaptureControl.stopRecording("test1")) {
+        return EXIT_FAILURE;
+    }
+
+    return EXIT_SUCCESS;
+}

--- a/examples/vicon/vicon_plot_test.cc
+++ b/examples/vicon/vicon_plot_test.cc
@@ -33,9 +33,10 @@ main()
     }
 
     // Plot for 30s
+    auto &object = vicon.getObjectData(0);
     const auto startTime = now();
     do {
-        if (!vicon.getObjectData(0).update()) {
+        if (!object.update()) {
             std::this_thread::sleep_for(25ms);
         }
     } while ((now() - startTime) <= 30s);

--- a/examples/vicon/vicon_plot_test.cc
+++ b/examples/vicon/vicon_plot_test.cc
@@ -1,6 +1,5 @@
 // C++ includes
 #include <chrono>
-#include <cstdlib>
 #include <iostream>
 #include <thread>
 
@@ -32,14 +31,12 @@ main()
         return EXIT_FAILURE;
     }
 
-    // Plot for 30s
-    auto &object = vicon.getObject(0);
-    const auto startTime = now();
+    auto &plotter = vicon.getObject(0);
     do {
-        if (!object.update()) {
+        if (!plotter.update()) {
             std::this_thread::sleep_for(25ms);
         }
-    } while ((now() - startTime) <= 30s);
+    } while (plotter.isOpen());
 
     if (!viconCaptureControl.stopRecording("test1")) {
         return EXIT_FAILURE;

--- a/examples/vicon/vicon_plot_test.cc
+++ b/examples/vicon/vicon_plot_test.cc
@@ -33,7 +33,7 @@ main()
     }
 
     // Plot for 30s
-    auto &object = vicon.getObjectData(0);
+    auto &object = vicon.getObject(0);
     const auto startTime = now();
     do {
         if (!object.update()) {

--- a/examples/vicon/vicon_plot_test.cc
+++ b/examples/vicon/vicon_plot_test.cc
@@ -13,6 +13,11 @@ using namespace BoBRobotics::Vicon;
 using namespace std::literals;
 using namespace units::angle;
 
+auto now()
+{
+    return std::chrono::high_resolution_clock::now();
+}
+
 int
 main()
 {
@@ -26,7 +31,15 @@ main()
     if (!viconCaptureControl.startRecording("test1")) {
         return EXIT_FAILURE;
     }
-    std::this_thread::sleep_for(30s);
+
+    // Plot for 30s
+    const auto startTime = now();
+    do {
+        if (!vicon.getObjectData(0).update()) {
+            std::this_thread::sleep_for(25ms);
+        }
+    } while ((now() - startTime) <= 30s);
+
     if (!viconCaptureControl.stopRecording("test1")) {
         return EXIT_FAILURE;
     }

--- a/examples/vicon/vicon_test.cc
+++ b/examples/vicon/vicon_test.cc
@@ -25,8 +25,8 @@ main()
     if (!viconCaptureControl.startRecording("test1")) {
         return EXIT_FAILURE;
     }
+    auto &objectData = vicon.getObjectData(0);
     for (int i = 0; i < 10000; i++) {
-        auto objectData = vicon.getObjectData(0);
         const auto position = objectData.getPosition<>();
         const auto attitude = objectData.getAttitude<degree_t>();
         std::cout << position[0] << ", " << position[1] << ", " << position[2] << ", "

--- a/examples/vicon/vicon_test.cc
+++ b/examples/vicon/vicon_test.cc
@@ -25,10 +25,10 @@ main()
     if (!viconCaptureControl.startRecording("test1")) {
         return EXIT_FAILURE;
     }
-    auto &objectData = vicon.getObject(0);
+    auto &object = vicon.getObject(0);
     for (int i = 0; i < 10000; i++) {
-        const auto position = objectData.getPosition<>();
-        const auto attitude = objectData.getAttitude<degree_t>();
+        const auto position = object.getPosition<>();
+        const auto attitude = object.getAttitude<degree_t>();
         std::cout << position[0] << ", " << position[1] << ", " << position[2] << ", "
                   << attitude[0] << ", " << attitude[1] << ", " << attitude[2] << std::endl;
     }

--- a/examples/vicon/vicon_test.cc
+++ b/examples/vicon/vicon_test.cc
@@ -25,7 +25,7 @@ main()
     if (!viconCaptureControl.startRecording("test1")) {
         return EXIT_FAILURE;
     }
-    auto &objectData = vicon.getObjectData(0);
+    auto &objectData = vicon.getObject(0);
     for (int i = 0; i < 10000; i++) {
         const auto position = objectData.getPosition<>();
         const auto attitude = objectData.getAttitude<degree_t>();

--- a/examples/vicon/vicon_velocity_test.cc
+++ b/examples/vicon/vicon_velocity_test.cc
@@ -23,8 +23,8 @@ int main()
     if (!viconCaptureControl.startRecording("test1")) {
         return EXIT_FAILURE;
     }
+    auto &objectData = vicon.getObjectData(0);
     for (int i = 0; i < 10000; i++) {
-        auto objectData = vicon.getObjectData(0);
         const auto &velocity = objectData.getVelocity();
 
         std::cout << velocity[0] << ", " << velocity[1] << ", " << velocity[2] << std::endl;

--- a/examples/vicon/vicon_velocity_test.cc
+++ b/examples/vicon/vicon_velocity_test.cc
@@ -23,7 +23,7 @@ int main()
     if (!viconCaptureControl.startRecording("test1")) {
         return EXIT_FAILURE;
     }
-    auto &objectData = vicon.getObjectData(0);
+    auto &objectData = vicon.getObject(0);
     for (int i = 0; i < 10000; i++) {
         const auto &velocity = objectData.getVelocity();
 

--- a/examples/vicon/vicon_velocity_test.cc
+++ b/examples/vicon/vicon_velocity_test.cc
@@ -13,7 +13,7 @@ using namespace std::literals;
 
 int main()
 {
-    UDPClient<ObjectDataVelocity> vicon(51001);
+    UDPClient<ObjectVelocity> vicon(51001);
     CaptureControl viconCaptureControl("192.168.1.100", 3003, "c:\\users\\ad374\\Desktop");
     while (vicon.getNumObjects() == 0) {
         std::this_thread::sleep_for(1s);
@@ -23,9 +23,9 @@ int main()
     if (!viconCaptureControl.startRecording("test1")) {
         return EXIT_FAILURE;
     }
-    auto &objectData = vicon.getObject(0);
+    auto &object = vicon.getObject(0);
     for (int i = 0; i < 10000; i++) {
-        const auto &velocity = objectData.getVelocity();
+        const auto &velocity = object.getVelocity();
 
         std::cout << velocity[0] << ", " << velocity[1] << ", " << velocity[2] << std::endl;
     }

--- a/projects/stone_cx/simulatorVicon.cc
+++ b/projects/stone_cx/simulatorVicon.cc
@@ -78,7 +78,7 @@ int main(int argc, char *argv[])
         return EXIT_FAILURE;
     }
 
-    std::cout << "Start VICON frame:" << vicon.getObjectData(0).getFrameNumber() << std::endl;
+    std::cout << "Start VICON frame:" << vicon.getObject(0).getFrameNumber() << std::endl;
 
     // Loop until second joystick button is pressed
     bool outbound = true;
@@ -98,7 +98,7 @@ int main(int argc, char *argv[])
         }
 
         // Read data from VICON system
-        auto &objectData = vicon.getObjectData(0);
+        auto &objectData = vicon.getObject(0);
         const auto &velocity = objectData.getVelocity();
         const auto &attitude = objectData.getAttitude();
 

--- a/projects/stone_cx/simulatorVicon.cc
+++ b/projects/stone_cx/simulatorVicon.cc
@@ -56,7 +56,7 @@ int main(int argc, char *argv[])
     // Build connectivity
     //---------------------------------------------------------------------------
     buildConnectivity();
-    
+
     initstone_cx();
 
 #ifdef RECORD_ELECTROPHYS
@@ -66,7 +66,7 @@ int main(int argc, char *argv[])
     GeNNUtils::AnalogueCSVRecorder<scalar> cpu4Recorder("cpu4.csv", rCPU4, Parameters::numCPU4, "CPU4");
     GeNNUtils::AnalogueCSVRecorder<scalar> cpu1Recorder("cpu1.csv", rCPU1, Parameters::numCPU1, "CPU1");
 #endif  // RECORD_ELECTROPHYS
-    
+
     // Wait for VICON system to track some objects
     while(vicon.getNumObjects() == 0) {
         std::this_thread::sleep_for(1s);
@@ -88,20 +88,20 @@ int main(int argc, char *argv[])
     for(;; numTicks++) {
         // Record time at start of tick
         const auto tickStartTime = std::chrono::high_resolution_clock::now();
-        
+
         // Read from joystick
         joystick.update();
-        
+
         // Stop if 2nd button is pressed
         if(joystick.isDown(JButton::B)) {
             break;
         }
-        
+
         // Read data from VICON system
-        auto objectData = vicon.getObjectData(0);
+        auto &objectData = vicon.getObjectData(0);
         const auto &velocity = objectData.getVelocity();
         const auto &attitude = objectData.getAttitude();
-        
+
         /*
          * Update TL input
          * **TODO**: We could update definitions.h etc. to use physical unit types,
@@ -137,7 +137,7 @@ int main(int argc, char *argv[])
         if(outbound) {
             // Use joystick to drive motor
             motor.drive(joystick, RobotParameters::joystickDeadzone);
-            
+
             // If first button is pressed switch to returning home
             if(joystick.isDown(JButton::A)) {
                 std::cout << "Max CPU4 level r=" << *std::max_element(&rCPU4[0], &rCPU4[Parameters::numCPU4]) << ", i=" << *std::max_element(&iCPU4[0], &iCPU4[Parameters::numCPU4]) << std::endl;
@@ -150,16 +150,16 @@ int main(int argc, char *argv[])
         else {
             driveMotorFromCPU1(motor, (numTicks % 100) == 0);
         }
-        
+
         // Record time at end of tick
         const auto tickEndTime = std::chrono::high_resolution_clock::now();
-        
+
         // Calculate tick duration (in microseconds)
         const int64_t tickMicroseconds = std::chrono::duration_cast<chrono::microseconds>(tickEndTime - tickStartTime).count();
-        
+
         // Add to total
         totalMicroseconds += tickMicroseconds;
-        
+
         // If there is time left in tick, sleep for remainder
         if(tickMicroseconds < RobotParameters::targetTickMicroseconds) {
             std::this_thread::sleep_for(std::chrono::microseconds(RobotParameters::targetTickMicroseconds - tickMicroseconds));
@@ -169,13 +169,13 @@ int main(int argc, char *argv[])
             numOverflowTicks++;
         }
     }
-    
+
     // Show overflow stats
     std::cout << numOverflowTicks << "/" << numTicks << " ticks overflowed, mean tick time: " << (double)totalMicroseconds / (double)numTicks << "uS" << std::endl;
 
     // Stop motor
     motor.tank(0.0f, 0.0f);
-    
+
     // Stop capture
     if(!viconCaptureControl.stopRecording("test")) {
         return EXIT_FAILURE;

--- a/projects/stone_cx/simulatorVicon.cc
+++ b/projects/stone_cx/simulatorVicon.cc
@@ -35,7 +35,7 @@ int main(int argc, char *argv[])
     Robots::Norbot motor;
 
     // Create VICON UDP interface
-    Vicon::UDPClient<Vicon::ObjectDataVelocity> vicon(51001);
+    Vicon::UDPClient<Vicon::ObjectVelocity> vicon(51001);
 
     // Create VICON capture control interface
     Vicon::CaptureControl viconCaptureControl("192.168.1.100", 3003,
@@ -98,9 +98,9 @@ int main(int argc, char *argv[])
         }
 
         // Read data from VICON system
-        auto &objectData = vicon.getObject(0);
-        const auto &velocity = objectData.getVelocity();
-        const auto &attitude = objectData.getAttitude();
+        auto &object = vicon.getObject(0);
+        const auto &velocity = object.getVelocity();
+        const auto &attitude = object.getAttitude();
 
         /*
          * Update TL input
@@ -142,7 +142,7 @@ int main(int argc, char *argv[])
             if(joystick.isDown(JButton::A)) {
                 std::cout << "Max CPU4 level r=" << *std::max_element(&rCPU4[0], &rCPU4[Parameters::numCPU4]) << ", i=" << *std::max_element(&iCPU4[0], &iCPU4[Parameters::numCPU4]) << std::endl;
                 std::cout << "Returning home!" << std::endl;
-                std::cout << "Turn around VICON frame:" << objectData.getFrameNumber() << std::endl;
+                std::cout << "Turn around VICON frame:" << object.getFrameNumber() << std::endl;
                 outbound = false;
             }
         }

--- a/tools/camera_recorder/camera_recorder.cc
+++ b/tools/camera_recorder/camera_recorder.cc
@@ -39,7 +39,7 @@ int main()
 
     // Create unwrapper to unwrap camera output
     auto unwrapper = cam.createUnwrapper(unwrapSize);
-    
+
     // Create motor interface
     Norbot motor;
 
@@ -91,9 +91,9 @@ int main()
 
 #ifdef VICON_CAPTURE
                // Get tracking data
-               auto objectData = vicon.getObjectData(0);
-               const auto &position = objectData.getPosition<>();
-               const auto &attitude = objectData.getAttitude<>();
+               auto &objectData = vicon.getObjectData(0);
+               const auto position = objectData.getPosition<>();
+               const auto attitude = objectData.getAttitude<>();
 
                // Write to CSV
                data << filename << ", " << objectData.getFrameNumber() << ", "

--- a/tools/camera_recorder/camera_recorder.cc
+++ b/tools/camera_recorder/camera_recorder.cc
@@ -91,12 +91,12 @@ int main()
 
 #ifdef VICON_CAPTURE
                // Get tracking data
-               auto &objectData = vicon.getObject(0);
-               const auto position = objectData.getPosition<>();
-               const auto attitude = objectData.getAttitude<>();
+               auto &object = vicon.getObject(0);
+               const auto position = object.getPosition<>();
+               const auto attitude = object.getAttitude<>();
 
                // Write to CSV
-               data << filename << ", " << objectData.getFrameNumber() << ", "
+               data << filename << ", " << object.getFrameNumber() << ", "
                     << position[0].value() << ", " << position[1].value() << ", "
                     << position[2].value() << ", " << attitude[0].value() << ", "
                     << attitude[1].value() << ", " << attitude[2].value() << std::endl;

--- a/tools/camera_recorder/camera_recorder.cc
+++ b/tools/camera_recorder/camera_recorder.cc
@@ -91,7 +91,7 @@ int main()
 
 #ifdef VICON_CAPTURE
                // Get tracking data
-               auto &objectData = vicon.getObjectData(0);
+               auto &objectData = vicon.getObject(0);
                const auto position = objectData.getPosition<>();
                const auto attitude = objectData.getAttitude<>();
 

--- a/vicon/object_data_plotter.h
+++ b/vicon/object_data_plotter.h
@@ -21,8 +21,11 @@ class ObjectDataPlotter
   : public ObjectData
 {
 public:
-    void update(uint32_t frameNumber, millimeter_t x, millimeter_t y, millimeter_t z,
-                radian_t yaw, radian_t pitch, radian_t roll) {
+    ObjectDataPlotter() = default;
+    ObjectDataPlotter(const ObjectDataPlotter &) {}
+
+    void update(uint32_t frameNumber, millimeter_t x, millimeter_t y, millimeter_t z, radian_t yaw, radian_t pitch, radian_t roll)
+    {
         BaseObjectDataType::update(frameNumber, x, y, z, yaw, pitch, roll);
         m_NewData = true;
     }
@@ -51,7 +54,7 @@ public:
         return true;
     }
 private:
-    std::atomic<bool> m_NewData = false;
+    std::atomic<bool> m_NewData{ false };
 }; // ObjectDataPlotter
 } // Vicon
 } // BoBRobotics

--- a/vicon/object_data_plotter.h
+++ b/vicon/object_data_plotter.h
@@ -23,7 +23,12 @@ class ObjectDataPlotter
 {
 public:
     ObjectDataPlotter() = default;
-    ObjectDataPlotter(const ObjectDataPlotter &) {}
+    ObjectDataPlotter(const ObjectDataPlotter &&o2)
+    {
+        const auto pos = o2.getPosition<>();
+        const auto att = o2.getAttitude<>();
+        BaseObjectDataType::update(o2.getFrameNumber(), pos[0], pos[1], pos[2], att[0], att[1], att[2]);
+    }
 
     void update(uint32_t frameNumber, millimeter_t x, millimeter_t y, millimeter_t z, radian_t yaw, radian_t pitch, radian_t roll)
     {

--- a/vicon/object_data_plotter.h
+++ b/vicon/object_data_plotter.h
@@ -1,6 +1,7 @@
 #pragma once
 
 // BoB robotics includes
+#include "../common/plot_agent.h"
 #include "udp.h"
 
 // Third-party includes
@@ -38,18 +39,7 @@ public:
         }
 
         // Update plot
-        const auto position = getPosition<>();
-        const auto attitude = getAttitude<>();
-        const std::vector<double> vx{ position[0].value() };
-        const std::vector<double> vy{ position[1].value() };
-        const std::vector<double> vu{ units::math::cos(attitude[0]) };
-        const std::vector<double> vv{ units::math::sin(attitude[0]) };
-        const std::vector<int> x0 { 0 }, y0 { 0 };
-        matplotlibcpp::clf();
-        matplotlibcpp::plot(x0, y0, "r+");
-        matplotlibcpp::quiver(vx, vy, vu, vv);
-        matplotlibcpp::xlim(-2500, 2500);
-        matplotlibcpp::ylim(-2500, 2500);
+        plotAgent(*this, { -2500, 2500 }, { -2500, 2500 });
         matplotlibcpp::pause(0.01);
         return true;
     }

--- a/vicon/object_data_plotter.h
+++ b/vicon/object_data_plotter.h
@@ -1,0 +1,50 @@
+#pragma once
+
+// BoB robotics includes
+#include "udp.h"
+
+// Third-party includes
+#include "../third_party/matplotlibcpp.h"
+#include "../third_party/units.h"
+
+// Standard C++ includes
+#include <thread>
+
+namespace BoBRobotics {
+namespace Vicon {
+template<typename BaseObjectDataType = ObjectData>
+class ObjectDataPlotter
+  : public ObjectData {
+public:
+    ObjectDataPlotter() : m_PlotThread(run, this)
+    {}
+
+    void updatePlot() const
+    {
+        const auto position = getPosition<>();
+        const auto attitude = getAttitude<>();
+        // std::cout << "x: " << position[0] << ", y: " << position[1] << std::endl;
+        const std::vector<double> vx{ position[0].value() };
+        const std::vector<double> vy{ position[1].value() };
+        const std::vector<double> vu{ units::math::cos(attitude[0]) };
+        const std::vector<double> vv{ units::math::sin(attitude[0]) };
+        const std::vector<int> x0 { 0 }, y0 { 0 };
+        matplotlibcpp::clf();
+        matplotlibcpp::plot(x0, y0, "r+");
+        matplotlibcpp::quiver(vx, vy, vu, vv);
+        matplotlibcpp::xlim(-2500, 2500);
+        matplotlibcpp::ylim(-2500, 2500);
+        matplotlibcpp::pause(0.01);
+    }
+
+private:
+    std::thread m_PlotThread;
+
+    static void run(const ObjectDataPlotter *plotter)
+    {
+        while (true)
+            plotter->updatePlot();
+    }
+}; // ObjectDataPlotter
+} // Vicon
+} // BoBRobotics

--- a/vicon/object_plotter.h
+++ b/vicon/object_plotter.h
@@ -17,22 +17,22 @@ namespace BoBRobotics {
 namespace Vicon {
 using namespace std::literals;
 
-template<typename BaseObjectDataType = ObjectData>
-class ObjectDataPlotter
-  : public ObjectData
+template<typename BaseObjectType = Object>
+class ObjectPlotter
+  : public Object
 {
 public:
-    ObjectDataPlotter() = default;
-    ObjectDataPlotter(const ObjectDataPlotter &&o2)
+    ObjectPlotter() = default;
+    ObjectPlotter(const ObjectPlotter &&o2)
     {
         const auto pos = o2.getPosition<>();
         const auto att = o2.getAttitude<>();
-        BaseObjectDataType::update(o2.getFrameNumber(), pos[0], pos[1], pos[2], att[0], att[1], att[2]);
+        BaseObjectType::update(o2.getFrameNumber(), pos[0], pos[1], pos[2], att[0], att[1], att[2]);
     }
 
     void update(uint32_t frameNumber, millimeter_t x, millimeter_t y, millimeter_t z, radian_t yaw, radian_t pitch, radian_t roll)
     {
-        BaseObjectDataType::update(frameNumber, x, y, z, yaw, pitch, roll);
+        BaseObjectType::update(frameNumber, x, y, z, yaw, pitch, roll);
         m_NewData = true;
     }
 
@@ -50,6 +50,6 @@ public:
     }
 private:
     std::atomic<bool> m_NewData{ false };
-}; // ObjectDataPlotter
+}; // ObjectPlotter
 } // Vicon
 } // BoBRobotics

--- a/vicon/object_plotter.h
+++ b/vicon/object_plotter.h
@@ -44,10 +44,17 @@ public:
         }
 
         // Update plot
+        matplotlibcpp::figure(1);
         plotAgent(*this, { -2500, 2500 }, { -2500, 2500 });
         matplotlibcpp::pause(0.01);
         return true;
     }
+
+    bool isOpen()
+    {
+        return matplotlibcpp::fignum_exists(1);
+    }
+
 private:
     std::atomic<bool> m_NewData{ false };
 }; // ObjectPlotter

--- a/vicon/udp.h
+++ b/vicon/udp.h
@@ -233,7 +233,7 @@ public:
         return m_ObjectData.size();
     }
 
-    ObjectDataType getObjectData(unsigned int id)
+    ObjectDataType &getObjectData(unsigned int id)
     {
         std::lock_guard<std::mutex> guard(m_ObjectDataMutex);
         if(id < m_ObjectData.size()) {

--- a/vicon/udp.h
+++ b/vicon/udp.h
@@ -233,7 +233,7 @@ public:
         return m_ObjectData.size();
     }
 
-    ObjectDataType &getObjectData(unsigned int id)
+    ObjectDataType &getObject(unsigned int id)
     {
         std::lock_guard<std::mutex> guard(m_ObjectDataMutex);
         if(id < m_ObjectData.size()) {


### PR DESCRIPTION
The main point of this PR is to add a basic (2D) matplotlib plotter for the Vicon system.

But as I was working on it I decided that we might be better off changing the ``getObjectData()`` function to return the objects by reference rather than value. ``getPosition()`` and ``getAttitude()`` already copy the data from the object and it seems a bit unnecessary to copy everything twice. I've also stuck a mutex in ``ObjectData`` to stop data races (and this meant I had to add a copy constructor). As we're now returning a reference to the object rather than just its data I thought I'd made sense to rename all the ``ObjectData``s etc. to just ``Object``s.