### PR TITLE
More image database work

### DIFF
--- a/navigation/image_database.h
+++ b/navigation/image_database.h
@@ -57,7 +57,7 @@ struct Range
 
     size_t size() const
     {
-        return (separation == 0_mm) ? 1 : ((end - begin) / separation).to<size_t>();
+        return (separation == 0_mm) ? 1 : (1 + ((end - begin) / separation).to<size_t>());
     }
 };
 

--- a/navigation/image_database.h
+++ b/navigation/image_database.h
@@ -30,6 +30,7 @@ using namespace units::length;
 using namespace units::literals;
 using namespace units::math;
 
+//! A range of values in millimetres
 struct Range
 {
     millimeter_t begin;
@@ -60,6 +61,7 @@ struct Range
     }
 };
 
+//! An interface for reading from and writing to folders of images
 class ImageDatabase
 {
 public:
@@ -84,6 +86,7 @@ public:
         }
     };
 
+    //! Base class for GridRecorder and RouteRecorder
     class Recorder {
     public:
         ~Recorder()
@@ -93,13 +96,16 @@ public:
             }
         }
 
+        //! Get an object for writing additional metadata to
         cv::FileStorage &getMetadataWriter() { return m_YAML; }
 
+        //! Don't save new metadata when this class is destroyed
         void abortSave()
         {
             m_Recording = false;
         }
 
+        //! Save new metadata
         void save()
         {
             // End writing metadata
@@ -109,9 +115,11 @@ public:
             m_Recording = false;
         }
 
+        //! Current number of *new* entries for the ImageDatabase
         size_t size() const { return m_NewEntries.size(); }
 
-        std::string getImageFormat() { return m_ImageFormat; }
+        //! Get the format in which images will be saved
+        std::string getImageFormat() const { return m_ImageFormat; }
 
     private:
         ImageDatabase &m_ImageDatabase;
@@ -155,6 +163,7 @@ public:
         }
     };
 
+    //! For recording a grid of images at a fixed heading
     class GridRecorder : public Recorder {
     public:
         GridRecorder(ImageDatabase &imageDatabase, const Range &xrange, const Range &yrange,
@@ -173,6 +182,7 @@ public:
             zrange.check();
         }
 
+        //! Get the physical position represented by grid coordinates
         Vector3<millimeter_t> getPosition(const Vector3<int> &indexes)
         {
             BOB_ASSERT(indexes[0] < (int) m_Size[0] && indexes[1] < (int) m_Size[1] && indexes[2] < (int) m_Size[2]);
@@ -183,6 +193,7 @@ public:
             return position;
         }
 
+        //! Get a vector of all possible positions for this grid
         auto getPositions()
         {
             std::vector<Vector3<millimeter_t>> positions;
@@ -197,6 +208,7 @@ public:
             return positions;
         }
 
+        //! Save a new image into the database
         void record(const cv::Mat &image)
         {
             BOB_ASSERT((size_t) m_Current[2] < sizeZ());
@@ -215,6 +227,7 @@ public:
             }
         }
 
+        //! Save a new image into the database at the specified coordinates
         void record(const Vector3<int> &indexes, const cv::Mat &image)
         {
             const auto position = getPosition(indexes);
@@ -234,6 +247,7 @@ public:
         Vector3<int> m_Current;
     };
 
+    //! For saving images recorded along a route
     class RouteRecorder : public Recorder {
     public:
         RouteRecorder(ImageDatabase &imageDatabase, const std::string &imageFormat = "png")
@@ -242,6 +256,7 @@ public:
             BOB_ASSERT(!imageDatabase.isGrid());
         }
 
+        //! Save a new image taken at the specified pose
         void record(const Vector3<millimeter_t> &position, degree_t heading,
                     const cv::Mat &image)
         {

--- a/navigation/image_database.h
+++ b/navigation/image_database.h
@@ -214,13 +214,9 @@ public:
             BOB_ASSERT((size_t) m_Current[2] < sizeZ());
             record(m_Current, image);
 
-            if ((size_t) m_Current[0] < sizeX()) {
-                m_Current[0]++;
-            } else {
+            if ((size_t) ++m_Current[0] == sizeX()) {
                 m_Current[0] = 0;
-                if ((size_t) m_Current[1] < sizeY()) {
-                    m_Current[1]++;
-                } else {
+                if ((size_t) ++m_Current[1] == sizeY()) {
                     m_Current[1] = 0;
                     m_Current[2]++;
                 }

--- a/navigation/image_database.h
+++ b/navigation/image_database.h
@@ -445,7 +445,7 @@ private:
             os << "X [mm], Y [mm], Z [mm], Heading [degrees], Filename, Grid X, Grid Y, Grid Z" << std::endl;
             for (auto &e : m_Entries) {
                 writeEntry(os, e);
-                os << e.gridPosition[0] << ", " << e.gridPosition[1] << ", " << e.gridPosition[2];
+                os << ", " << e.gridPosition[0] << ", " << e.gridPosition[1] << ", " << e.gridPosition[2];
                 os << std::endl;
             }
         }

--- a/navigation/image_database.h
+++ b/navigation/image_database.h
@@ -28,7 +28,6 @@ namespace Navigation {
 using namespace units::angle;
 using namespace units::length;
 using namespace units::literals;
-using namespace units::math;
 
 //! A range of values in millimetres
 struct Range
@@ -386,7 +385,7 @@ public:
     {
         Vector3<int> iposition;
         std::transform(position.begin(), position.end(), iposition.begin(), [](auto mm) {
-            return static_cast<int>(round(mm));
+            return static_cast<int>(units::math::round(mm));
         });
         return getFilename(iposition, imageFormat);
     }

--- a/navigation/image_database.h
+++ b/navigation/image_database.h
@@ -297,8 +297,10 @@ public:
 
         // Read metadata from YAML file
         const auto metadataPath = m_Path / MetadataFilename;
-        if (!metadataPath.exists()) {
+        const bool metadataPresent = metadataPath.exists();
+        if (!metadataPresent) {
             std::cerr << "Warning, no " << MetadataFilename << " file found" << std::endl;
+            m_IsRoute = true;
         } else {
             // Parse metadata file
             cv::FileStorage metadataFile(metadataPath.str(), cv::FileStorage::READ);
@@ -336,6 +338,11 @@ public:
 
             Vector3<int> gridPosition;
             if (fields.size() >= 8) {
+                if (!metadataPresent) {
+                    // Infer that it is a grid
+                    m_IsRoute = false;
+                }
+
                 gridPosition[0] = std::stoi(fields[5]);
                 gridPosition[1] = std::stoi(fields[6]);
                 gridPosition[2] = std::stoi(fields[7]);

--- a/navigation/image_database.h
+++ b/navigation/image_database.h
@@ -21,6 +21,7 @@
 #include <iostream>
 #include <stdexcept>
 #include <string>
+#include <utility>
 #include <vector>
 
 namespace BoBRobotics {
@@ -32,19 +33,14 @@ using namespace units::literals;
 //! A range of values in millimetres
 struct Range
 {
-    millimeter_t begin;
-    millimeter_t end;
-    millimeter_t separation;
+    const millimeter_t begin;
+    const millimeter_t end;
+    const millimeter_t separation;
 
-    Range() = default;
-
-    Range(const millimeter_t value)
-    {
-        begin = end = value;
-        separation = 0_mm;
-    }
-
-    void check() const
+    Range(const std::pair<millimeter_t, millimeter_t> beginAndEnd, const millimeter_t separation)
+      : begin(beginAndEnd.first)
+      , end(beginAndEnd.second)
+      , separation(separation)
     {
         if (begin == end) {
             BOB_ASSERT(separation == 0_mm);
@@ -53,6 +49,10 @@ struct Range
             BOB_ASSERT(separation > 0_mm);
         }
     }
+
+    Range(const millimeter_t value)
+      : Range({value, value}, 0_mm)
+    {}
 
     size_t size() const
     {
@@ -184,9 +184,6 @@ public:
           , m_Current({ 0, 0, 0 })
         {
             BOB_ASSERT(!imageDatabase.isRoute());
-            xrange.check();
-            yrange.check();
-            zrange.check();
 
             // Save some extra, grid-specific metadata
             m_YAML << "grid" << "{"

--- a/navigation/image_database.h
+++ b/navigation/image_database.h
@@ -70,7 +70,7 @@ public:
         Vector3<millimeter_t> position;
         degree_t heading;
         filesystem::path path;
-        Vector3<int> gridPosition{ -1, -1, -1 }; //! For grid-type databases, indicates the x,y,z grid position
+        Vector3<int> gridPosition; //! For grid-type databases, indicates the x,y,z grid position
 
         cv::Mat load() const
         {

--- a/navigation/image_database.h
+++ b/navigation/image_database.h
@@ -12,13 +12,13 @@
 #include <opencv2/opencv.hpp>
 
 // Standard C includes
-#include <cstdio>
 #include <ctime>
 
 // Standard C++ includes
 #include <algorithm>
 #include <fstream>
 #include <iostream>
+#include <sstream>
 #include <stdexcept>
 #include <string>
 #include <utility>
@@ -387,9 +387,9 @@ public:
     static std::string getFilename(const unsigned int routeIndex,
                                    const std::string &imageFormat = "png")
     {
-        char buf[sizeof("image_00000.") + 1];
-        snprintf(buf, sizeof(buf), "image_%05d.", routeIndex);
-        return std::string(buf) + imageFormat;
+        std::ostringstream ss;
+        ss << "image_" << std::setw(5) << std::setfill('0') << routeIndex << "." << imageFormat;
+        return ss.str();
     }
 
     static std::string getFilename(const Vector3<millimeter_t> &position,
@@ -405,13 +405,12 @@ public:
     static std::string getFilename(const Vector3<int> &positionMM,
                                    const std::string &imageFormat = "png")
     {
-        const auto zeroPad = [](const auto value) {
-            char num[8];
-            snprintf(num, sizeof(num), "%+07d", value);
-            return std::string(num);
-        };
-        return "image_" + zeroPad(positionMM[0]) + "_" + zeroPad(positionMM[1]) +
-               "_" + zeroPad(positionMM[2]) + "." + imageFormat;
+        std::ostringstream ss;
+        ss << "image_" << std::setw(7) << std::setfill('0') << std::showpos << std::internal
+           << std::setw(7) << positionMM[0] << "_"
+           << std::setw(7) << positionMM[1] << "_"
+           << std::setw(7) << positionMM[2] << "." << imageFormat;
+        return ss.str();
     }
 
 private:

--- a/navigation/image_database.h
+++ b/navigation/image_database.h
@@ -190,8 +190,8 @@ public:
 
             // Save some extra, grid-specific metadata
             m_YAML << "grid" << "{"
-                   << "beginAt" << "[:" << m_Begin[0]() << m_Begin[1]() << m_Begin[2]() << "]"
-                   << "separation" << "[:" << m_Separation[0]() << m_Separation[1]() << m_Separation[2]() << "]"
+                   << "beginAtMM" << "[:" << m_Begin[0]() << m_Begin[1]() << m_Begin[2]() << "]"
+                   << "separationMM" << "[:" << m_Separation[0]() << m_Separation[1]() << m_Separation[2]() << "]"
                    << "size" << "[:" << (int) m_Size[0] << (int) m_Size[1] << (int) m_Size[2] << "]"
                    << "}";
         }

--- a/navigation/image_database.h
+++ b/navigation/image_database.h
@@ -130,16 +130,17 @@ public:
     private:
         ImageDatabase &m_ImageDatabase;
         const std::string m_ImageFormat;
-        cv::FileStorage m_YAML;
         bool m_Recording;
         std::vector<Entry> m_NewEntries;
 
     protected:
+        cv::FileStorage m_YAML;
+
         Recorder(ImageDatabase &imageDatabase, const bool isRoute, const std::string imageFormat)
           : m_ImageDatabase(imageDatabase)
           , m_ImageFormat(imageFormat)
-          , m_YAML(".yml", cv::FileStorage::WRITE | cv::FileStorage::MEMORY)
           , m_Recording(true)
+          , m_YAML(".yml", cv::FileStorage::WRITE | cv::FileStorage::MEMORY)
         {
             // Set this property of the ImageDatabase
             imageDatabase.m_IsRoute = isRoute;
@@ -186,6 +187,13 @@ public:
             xrange.check();
             yrange.check();
             zrange.check();
+
+            // Save some extra, grid-specific metadata
+            m_YAML << "grid" << "{"
+                   << "beginAt" << "[:" << m_Begin[0]() << m_Begin[1]() << m_Begin[2]() << "]"
+                   << "separation" << "[:" << m_Separation[0]() << m_Separation[1]() << m_Separation[2]() << "]"
+                   << "size" << "[:" << (int) m_Size[0] << (int) m_Size[1] << (int) m_Size[2] << "]"
+                   << "}";
         }
 
         //! Get the physical position represented by grid coordinates

--- a/navigation/image_database.h
+++ b/navigation/image_database.h
@@ -176,7 +176,7 @@ public:
         auto getPositions()
         {
             std::vector<Vector3<millimeter_t>> positions;
-            const size_t s = size();
+            const size_t s = maximumSize();
             positions.reserve(s);
             for (size_t i = 0; i < s; i++) {
                 positions.emplace_back(getPosition(i));

--- a/tools/ant_world_db_creator/.gitignore
+++ b/tools/ant_world_db_creator/.gitignore
@@ -1,4 +1,7 @@
 /ant_world_db_creator
 /ant_world_map_creator
+
+# Image database files
 *.png
 *.csv
+*.yaml

--- a/tools/ant_world_db_creator/ant_world_db_creator.cc
+++ b/tools/ant_world_db_creator/ant_world_db_creator.cc
@@ -96,7 +96,6 @@ protected:
 
             // Write to image database
             record(frame);
-            count++;
         }
     }
 

--- a/tools/ant_world_db_creator/ant_world_db_creator.cc
+++ b/tools/ant_world_db_creator/ant_world_db_creator.cc
@@ -126,14 +126,8 @@ public:
         const auto &worldMaxBound = m_Renderer.getWorld().getMaxBound();
 
         // Make GridRecorder
-        Range xrange;
-        xrange.begin = worldMinBound[0];
-        xrange.end = worldMaxBound[0];
-        xrange.separation = gridSpacing;
-        Range yrange;
-        yrange.begin = worldMinBound[1];
-        yrange.end = worldMaxBound[1];
-        yrange.separation = gridSpacing;
+        Range xrange({worldMinBound[0], worldMaxBound[0]}, gridSpacing);
+        Range yrange({worldMinBound[1], worldMaxBound[1]}, gridSpacing);
         auto gridRecorder = m_Database.getGridRecorder(xrange, yrange, AgentHeight);
         addMetadata(gridRecorder);
 

--- a/tools/ant_world_db_creator/ant_world_db_creator.cc
+++ b/tools/ant_world_db_creator/ant_world_db_creator.cc
@@ -1,7 +1,14 @@
-// Standard C++ includes
-#include <string>
-#include <fstream>
-#include <iostream>
+
+// BoB robotics includes
+#include "libantworld/agent.h"
+#include "libantworld/common.h"
+#include "libantworld/renderer.h"
+#include "libantworld/route_continuous.h"
+#include "navigation/image_database.h"
+#include "video/opengl.h"
+
+// Third-party includes
+#include "third_party/path.h"
 
 // OpenGL includes
 #include <GL/glew.h>
@@ -9,20 +16,16 @@
 // GLFW
 #include <GLFW/glfw3.h>
 
-// BoB robotics includes
-#include "navigation/image_database.h"
-#include "video/opengl.h"
-
-// Libantworld includes
-#include "libantworld/agent.h"
-#include "libantworld/common.h"
-#include "libantworld/renderer.h"
-#include "libantworld/route_continuous.h"
-
-// Third-party includes
-#include "third_party/path.h"
+// Standard C++ includes
+#include <algorithm>
+#include <string>
+#include <fstream>
+#include <iostream>
+#include <tuple>
+#include <vector>
 
 using namespace BoBRobotics;
+using namespace BoBRobotics::Navigation;
 using namespace units::angle;
 using namespace units::length;
 using namespace units::literals;
@@ -42,20 +45,135 @@ void handleGLError(GLenum, GLenum, GLuint, GLenum, GLsizei, const GLchar *messag
 }
 }
 
-int main(int argc, char *argv[])
+/*
+* I've set the width of the image to be the same as the (raw) unwrapped
+* images we get from the robot gantry, but the height is greater (cf. 58)
+* because I wanted to keep the aspect ratio as it was (200x40).
+*      -- AD
+*/
+const unsigned RenderWidth = 720;
+const unsigned RenderHeight = 150;
+
+using Pose = std::tuple<meter_t, meter_t, degree_t>;
+
+class AntWorldDatabaseCreator {
+protected:
+    ImageDatabase m_Database;
+    GLFWwindow *m_Window;
+    AntWorld::Renderer m_Renderer;
+    AntWorld::AntAgent m_Agent;
+
+    AntWorldDatabaseCreator(const std::string &databaseName, GLFWwindow *window)
+      : m_Database(databaseName)
+      , m_Window(window)
+      , m_Renderer(256, 0.001, 1000.0, 360_deg)
+      , m_Agent(window, m_Renderer, RenderWidth, RenderHeight)
+    {
+        BOB_ASSERT(m_Database.empty());
+
+        // Create renderer
+        m_Renderer.getWorld().load("../../libantworld/world5000_gray.bin",
+                                   {0.0f, 1.0f, 0.0f}, {0.898f, 0.718f, 0.353f});
+    }
+
+    template<typename RecordOp>
+    void run(const std::vector<Pose> &poses, RecordOp record)
+    {
+        // Host OpenCV array to hold pixels read from screen
+        cv::Mat frame(RenderHeight, RenderWidth, CV_8UC3);
+
+        for (auto it = poses.cbegin(); !glfwWindowShouldClose(m_Window) && it < poses.cend(); ++it) {
+            meter_t x, y;
+            degree_t heading;
+            std::tie(x, y, heading) = *it;
+
+            // Update agent's position
+            m_Agent.setPosition(x, y, AgentHeight);
+            m_Agent.setAttitude(heading, 0_deg, 0_deg);
+
+            // Get current view
+            m_Agent.readFrameSync(frame);
+
+            // Write to image database
+            record(frame);
+        }
+    }
+
+    const millimeter_t AgentHeight = 1_cm;
+};
+
+class GridDatabaseCreator : AntWorldDatabaseCreator {
+public:
+    GridDatabaseCreator(GLFWwindow *window)
+      : AntWorldDatabaseCreator("world5000_grid", window)
+    {}
+
+    void runForGrid()
+    {
+        const millimeter_t gridSpacing = 10_cm;
+
+        // Get world bounds
+        const auto &worldMinBound = m_Renderer.getWorld().getMinBound();
+        const auto &worldMaxBound = m_Renderer.getWorld().getMaxBound();
+
+        // Grid parameters
+        Range xrange;
+        xrange.begin = worldMinBound[0];
+        xrange.end = worldMaxBound[0];
+        xrange.separation = gridSpacing;
+        Range yrange;
+        yrange.begin = worldMinBound[1];
+        yrange.end = worldMaxBound[1];
+        yrange.separation = gridSpacing;
+
+        // Make GridRecorder and convert positions to poses
+        auto gridRecorder = m_Database.getGridRecorder(xrange, yrange, AgentHeight);
+        const auto positions = gridRecorder.getPositions();
+        std::vector<Pose> poses;
+        poses.reserve(positions.size());
+        const auto pos2pose = [](const auto &pos) {
+            return std::make_tuple<meter_t, meter_t, degree_t>(pos[0], pos[1], 0_deg);
+        };
+        std::transform(positions.cbegin(), positions.cend(), std::back_inserter(poses), pos2pose);
+
+        // Record image database
+        run(poses, [&gridRecorder](const cv::Mat &image) { gridRecorder.record(image); });
+    }
+};
+
+class RouteDatabaseCreator : AntWorldDatabaseCreator {
+public:
+    RouteDatabaseCreator(const std::string &databaseName, GLFWwindow *window,
+                         AntWorld::RouteContinuous &route)
+      : AntWorldDatabaseCreator(databaseName, window)
+      , m_Route(route)
+    {}
+
+    void runForRoute()
+    {
+        const millimeter_t pathStep = 1_cm;
+
+        // Make vector of agent's poses
+        std::vector<Pose> poses;
+        for (auto distance = 0_mm; distance < m_Route.getLength(); distance += pathStep) {
+            poses.emplace_back(m_Route.getPosition(distance));
+        }
+
+        // Record image database
+        auto routeRecorder = m_Database.getRouteRecorder();
+        run(poses, [&routeRecorder, this](const cv::Mat &image) {
+            const auto pos = m_Agent.getPosition();
+            routeRecorder.record({pos[0], pos[1], pos[2]}, m_Agent.getAttitude()[0], image);
+        });
+    }
+
+private:
+    AntWorld::RouteContinuous &m_Route;
+};
+
+int
+main(int argc, char **argv)
 {
-    const millimeter_t pathStep = 1_cm;
-    const millimeter_t gridSpacing = 10_cm;
-
-    /*
-     * I've set the width of the image to be the same as the (raw) unwrapped
-     * images we get from the robot gantry, but the height is greater (cf. 58)
-     * because I wanted to keep the aspect ratio as it was (200x40).
-     *      -- AD
-     */
-    const unsigned int renderWidth = 720;
-    const unsigned int renderHeight = 150;
-
     // Set GLFW error callback
     glfwSetErrorCallback(handleGLFWError);
 
@@ -69,7 +187,7 @@ int main(int argc, char *argv[])
     glfwWindowHint(GLFW_RESIZABLE, false);
 
     // Create a windowed mode window and its OpenGL context
-    GLFWwindow *window = glfwCreateWindow(renderWidth, renderHeight, "Ant world", nullptr, nullptr);
+    GLFWwindow *window = glfwCreateWindow(RenderWidth, RenderHeight, "Ant world", nullptr, nullptr);
     if(!window)
     {
         glfwTerminate();
@@ -102,108 +220,26 @@ int main(int argc, char *argv[])
 
     glEnable(GL_TEXTURE_2D);
 
-    // Should we follow route or grid
-    const bool followRoute = argc > 1;
-
-    // Create route object and load route file specified by command line
-    AntWorld::RouteContinuous route(0.2f, 800);
-
-    std::string databaseName;
-    if (followRoute) {
-        // Load route
+    if (argc > 1) {
+        // Create route object and load route file specified by command line
+        AntWorld::RouteContinuous route(0.2f, 800);
         if (!route.load(argv[1])) {
             return 1;
         }
 
         // Get filename from route path
-        databaseName = filesystem::path(argv[1]).filename();
+        std::string databaseName = filesystem::path(argv[1]).filename();
 
         // If it exists, remove extension
         const size_t pos = databaseName.find_last_of(".");
         if (pos != std::string::npos) {
-             databaseName = databaseName.substr(0, pos);
+            databaseName = databaseName.substr(0, pos);
         }
+
+        RouteDatabaseCreator creator(databaseName, window, route);
+        creator.runForRoute();
     } else {
-        databaseName = "world5000_grid";
+        GridDatabaseCreator creator(window);
+        creator.runForGrid();
     }
-
-    // Create renderer
-    AntWorld::Renderer renderer(256, 0.001, 1000.0, 360_deg);
-    renderer.getWorld().load("../../libantworld/world5000_gray.bin",
-                             {0.0f, 1.0f, 0.0f}, {0.898f, 0.718f, 0.353f});
-
-    // Create agent object
-    AntWorld::AntAgent agent(window, renderer, renderWidth, renderHeight);
-
-    // Get world bounds
-    const auto &worldMinBound = renderer.getWorld().getMinBound();
-    const auto &worldMaxBound = renderer.getWorld().getMaxBound();
-
-    // Create ImageDatabase
-    Navigation::ImageDatabase database(databaseName);
-
-    // Host OpenCV array to hold pixels read from screen
-    cv::Mat frame(renderHeight, renderWidth, CV_8UC3);
-
-    size_t routePosition = 0;
-    size_t currentGridX = 0;
-    size_t currentGridY = 0;
-    const millimeter_t z = 1_cm; // agent's height is fixed
-    degree_t heading = 0_deg;
-
-    // While the window isn't forcibly being closed
-    while (!glfwWindowShouldClose(window)) {
-        // If we should be following route, get position from route
-        millimeter_t x = 0_mm;
-        millimeter_t y = 0_mm;
-        if(followRoute) {
-            std::tie(x, y, heading) = route.getPosition(pathStep * routePosition);
-        }
-        else {
-            x = worldMinBound[0] + (gridSpacing * currentGridX);
-            y = worldMinBound[1] + (gridSpacing * currentGridY);
-        }
-
-        // Update pose
-        agent.setPosition(x, y, z);
-        agent.setAttitude(heading, 0_deg, 0_deg);
-
-        // Read frame
-        agent.readFrame(frame);
-
-        // Write to image database
-        database.addImage(frame, x, y, z, heading, followRoute);
-
-        // Poll for and process events
-        glfwPollEvents();
-
-        // If we're following a route
-        if(followRoute) {
-            // Make next step
-            routePosition++;
-
-            // If we've gone over end of route, stop
-            if((routePosition * pathStep) > route.getLength()) {
-                break;
-            }
-        }
-        else {
-
-            // Move to next X
-            currentGridX++;
-
-            // If we've reached the X edge of the world, move to start of next Y
-            if(worldMinBound[0] + (currentGridX * gridSpacing) > worldMaxBound[0]) {
-                currentGridY++;
-                currentGridX = 0;
-            }
-
-            // If we've reached the Y edge of the world, stop
-            if(worldMinBound[1] + (currentGridY * gridSpacing) > worldMaxBound[1]) {
-                break;
-            }
-        }
-    }
-
-    return EXIT_SUCCESS;
 }

--- a/tools/ant_world_db_creator/ant_world_db_creator.cc
+++ b/tools/ant_world_db_creator/ant_world_db_creator.cc
@@ -96,13 +96,17 @@ protected:
 
             // Write to image database
             record(frame);
+            count++;
         }
     }
 
     void addMetadata(ImageDatabase::Recorder &recorder)
     {
         // Record "camera" info
-        recorder.getMetadataWriter() << "camera" << m_Agent << "needsUnwrapping" << false;
+        auto &metadata = recorder.getMetadataWriter();
+        metadata << "camera" << m_Agent
+                 << "needsUnwrapping" << false
+                 << "isGreyscale" << false;
     }
 
     const millimeter_t AgentHeight = 1_cm;

--- a/tools/ant_world_db_creator/ant_world_db_creator.cc
+++ b/tools/ant_world_db_creator/ant_world_db_creator.cc
@@ -96,7 +96,14 @@ protected:
 
             // Write to image database
             record(frame);
+            count++;
         }
+    }
+
+    void addMetadata(ImageDatabase::Recorder &recorder)
+    {
+        // Record "camera" info
+        recorder.getMetadataWriter() << "camera" << m_Agent << "needsUnwrapping" << false;
     }
 
     const millimeter_t AgentHeight = 1_cm;
@@ -116,7 +123,7 @@ public:
         const auto &worldMinBound = m_Renderer.getWorld().getMinBound();
         const auto &worldMaxBound = m_Renderer.getWorld().getMaxBound();
 
-        // Grid parameters
+        // Make GridRecorder
         Range xrange;
         xrange.begin = worldMinBound[0];
         xrange.end = worldMaxBound[0];
@@ -125,9 +132,10 @@ public:
         yrange.begin = worldMinBound[1];
         yrange.end = worldMaxBound[1];
         yrange.separation = gridSpacing;
-
-        // Make GridRecorder and convert positions to poses
         auto gridRecorder = m_Database.getGridRecorder(xrange, yrange, AgentHeight);
+        addMetadata(gridRecorder);
+
+        // Convert positions to poses
         const auto positions = gridRecorder.getPositions();
         std::vector<Pose> poses;
         poses.reserve(positions.size());
@@ -161,6 +169,8 @@ public:
 
         // Record image database
         auto routeRecorder = m_Database.getRouteRecorder();
+        addMetadata(routeRecorder);
+
         run(poses, [&routeRecorder, this](const cv::Mat &image) {
             const auto pos = m_Agent.getPosition();
             routeRecorder.record({pos[0], pos[1], pos[2]}, m_Agent.getAttitude()[0], image);

--- a/tools/gantry_db_creator/gantry_db_creator.cc
+++ b/tools/gantry_db_creator/gantry_db_creator.cc
@@ -42,7 +42,10 @@ main()
         // Save images into a folder called gantry
         Navigation::ImageDatabase database("gantry");
         auto gridRecorder = database.getGridRecorder(xrange, yrange, z);
-        gridRecorder.getMetadataWriter() << "camera" << cam << "needsUnwrapping" << true;
+        auto &metadata = gridRecorder.getMetadataWriter();
+        metadata << "camera" << cam
+                 << "needsUnwrapping" << true
+                 << "isGreyscale" << false;
 
         cv::Mat frame(imSize, CV_8UC3);
         for (size_t x = 0, y = 0; x < gridRecorder.sizeX(); ) {

--- a/tools/gantry_db_creator/gantry_db_creator.cc
+++ b/tools/gantry_db_creator/gantry_db_creator.cc
@@ -17,14 +17,8 @@ using namespace BoBRobotics;
 int
 main()
 {
-    Navigation::Range xrange;
-    xrange.begin = 0_mm;
-    xrange.end = 100_mm;
-    xrange.separation = 100_mm;
-    Navigation::Range yrange;
-    yrange.begin = 0_mm;
-    yrange.end = 1700_mm;
-    yrange.separation = 100_mm;
+    Navigation::Range xrange({ 0_mm, 100_mm }, 100_mm);
+    Navigation::Range yrange({ 0_mm, 1700_mm }, 100_mm);
     const auto z = 200_mm;
 
     try {

--- a/tools/gantry_db_creator/gantry_db_creator.cc
+++ b/tools/gantry_db_creator/gantry_db_creator.cc
@@ -42,7 +42,7 @@ main()
                  << "isGreyscale" << false;
 
         cv::Mat frame(imSize, CV_8UC3);
-        for (int x = 0, y = 0; x < static_cast<int>(gridRecorder.sizeX()); ) {
+        for (size_t x = 0, y = 0; x < gridRecorder.sizeX(); ) {
             // Move gantry to next position
             const auto pos = gridRecorder.getPosition({ x, y, 0 });
             gantry.setPosition(pos[0], pos[1], pos[2]);
@@ -63,7 +63,7 @@ main()
 
             // If we haven't finished moving along y, move along one more
             if ((x % 2) == 0) {
-                if (y < static_cast<int>(gridRecorder.size())) {
+                if (y < gridRecorder.size()) {
                     y++;
                     continue;
                 }

--- a/tools/gantry_db_creator/gantry_db_creator.cc
+++ b/tools/gantry_db_creator/gantry_db_creator.cc
@@ -42,6 +42,7 @@ main()
         // Save images into a folder called gantry
         Navigation::ImageDatabase database("gantry");
         auto gridRecorder = database.getGridRecorder(xrange, yrange, z);
+        gridRecorder.getMetadataWriter() << "camera" << cam << "needsUnwrapping" << true;
 
         cv::Mat frame(imSize, CV_8UC3);
         for (size_t x = 0, y = 0; x < gridRecorder.sizeX(); ) {

--- a/tools/gantry_db_creator/gantry_db_creator.cc
+++ b/tools/gantry_db_creator/gantry_db_creator.cc
@@ -42,14 +42,14 @@ main()
                  << "isGreyscale" << false;
 
         cv::Mat frame(imSize, CV_8UC3);
-        for (size_t x = 0, y = 0; x < gridRecorder.sizeX(); ) {
+        for (int x = 0, y = 0; x < static_cast<int>(gridRecorder.sizeX()); ) {
             // Move gantry to next position
             const auto pos = gridRecorder.getPosition({ x, y, 0 });
             gantry.setPosition(pos[0], pos[1], pos[2]);
 
             // While gantry is moving, poll for user keypress
             while (gantry.isMoving()) {
-                if (cv::waitKeyEx(1) & OS::KeyMask == OS::KeyCodes::Escape) {
+                if ((cv::waitKeyEx(1) & OS::KeyMask) == OS::KeyCodes::Escape) {
                     return 0;
                 }
             }
@@ -63,7 +63,7 @@ main()
 
             // If we haven't finished moving along y, move along one more
             if ((x % 2) == 0) {
-                if (y < gridRecorder.size()) {
+                if (y < static_cast<int>(gridRecorder.size())) {
                     y++;
                     continue;
                 }

--- a/video/input.h
+++ b/video/input.h
@@ -1,18 +1,20 @@
 #pragma once
 
-// Standard C++ includes
-#include <stdexcept>
-#include <string>
+// BoBRobotics includes
+#include "../imgproc/opencv_unwrap_360.h"
 
 // OpenCV
 #include <opencv2/opencv.hpp>
 
-// BoBRobotics includes
-#include "../imgproc/opencv_unwrap_360.h"
+// Standard C++ includes
+#include <chrono>
+#include <stdexcept>
+#include <string>
+#include <thread>
 
 namespace BoBRobotics {
 namespace Video {
-#define DefaultCameraName "unknown_camera"
+using namespace std::literals;
 
 //----------------------------------------------------------------------------
 // BoBRobotics::Video::Input
@@ -91,6 +93,15 @@ public:
      */
     virtual bool readFrame(cv::Mat &outFrame) = 0;
 
+    //! Read a frame synchronously, blocking until a new frame is received
+    void readFrameSync(cv::Mat &outFrame)
+    {
+        while (!readFrame(outFrame)) {
+            std::this_thread::sleep_for(10ms);
+        }
+    }
+
+    static constexpr const char *DefaultCameraName = "unknown_camera";
 private:
     cv::Mat m_IntermediateFrame;
 }; // Input

--- a/video/input.h
+++ b/video/input.h
@@ -101,9 +101,25 @@ public:
         }
     }
 
+    //! Allows OpenCV to serialise info about this Input
+    void write(cv::FileStorage& fs) const
+    {
+        fs << "{";
+        fs << "name" << getCameraName();
+        fs << "resolution" << getOutputSize();
+        fs << "isPanoramic" << needsUnwrapping();
+        fs << "}";
+    }
+
     static constexpr const char *DefaultCameraName = "unknown_camera";
 private:
     cv::Mat m_IntermediateFrame;
 }; // Input
+
+//! More OpenCV boilerplate
+inline void write(cv::FileStorage &fs, const std::string &, const Input &camera)
+{
+    camera.write(fs);
+}
 } // Video
 } // BoBRobotics

--- a/video/opengl.h
+++ b/video/opengl.h
@@ -47,7 +47,7 @@ public:
     virtual bool readFrame(cv::Mat &outFrame) override
     {
         // Make sure frame is of right size and type
-        outFrame.create(m_ReadWidth, m_ReadHeight, CV_8UC3);
+        outFrame.create(m_ReadHeight, m_ReadWidth, CV_8UC3);
 
         // Read pixels from framebuffer into outFrame
         // **TODO** it should be theoretically possible to go directly from frame buffer to GpuMat


### PR DESCRIPTION
Hi Jamie,

I've just been doing some work on the image database code, changing a few things:
1. Recording extra metadata in a ``database_metadata.yaml`` file (database entries are still in a CSV file)
2. Changing to use ``GridRecorder`` and ``RouteRecorder`` classes for writing to image databases
3. Saving grid coordinates in addition to physical positions for grid databases

This is partly for making databases with the gantry (and transferring over old Matlab ones) and it would be useful to have a standardised way of recording the metadata for them, including parameters that we might want to be able to read in (e.g. unwrap parameters used etc.). But I'm hoping that this will also be useful for e.g. the library square data. If you're happy with the format I'll add an example of how to read this in in python to the repo for students and things.

The reason for saving the details about the grid size and spacing separately from the physical positions is because I found there were tiny floating point rounding errors when calculating the difference between e.g. the x positions, so it's much nicer to just have this parameter saved explicitly somewhere.

I reorganised ant_world_db_creator to use the new interface and I think it's fair to say that that part of the PR is a fairly dubious improvement :-/. There's a tidier example for the gantry:
https://github.com/BrainsOnBoard/bob_robotics/blob/more_image_database/tools/gantry_db_creator/gantry_db_creator.cc