### PR TITLE
Networking fixes

### DIFF
--- a/net/connection.h
+++ b/net/connection.h
@@ -72,6 +72,7 @@ public:
       : m_Buffer(DefaultBufferSize)
       , m_Socket(std::forward<Ts>(args)...)
       , m_SendMutex(std::make_unique<std::mutex>())
+      , m_CommandHandlersMutex(std::make_unique<std::mutex>())
     {}
 
     virtual ~Connection() override
@@ -88,9 +89,16 @@ public:
      *
      * e.g. if it's an IMG command, it should be handled by Video::NetSource.
      */
-    void addCommandHandler(const std::string commandName, const CommandHandler handler)
+    void addCommandHandler(const std::string &commandName, const CommandHandler handler)
     {
+        std::lock_guard<std::mutex> guard(*m_CommandHandlersMutex);
         m_CommandHandlers.emplace(commandName, handler);
+    }
+
+    void removeCommandHandler(const std::string &commandName)
+    {
+        std::lock_guard<std::mutex> guard(*m_CommandHandlersMutex);
+        m_CommandHandlers[commandName] = nullptr;
     }
 
     //! Read a specified number of bytes into a buffer
@@ -142,6 +150,7 @@ private:
     std::vector<char> m_Buffer;
     Socket m_Socket;
     std::unique_ptr<std::mutex> m_SendMutex;
+    std::unique_ptr<std::mutex> m_CommandHandlersMutex;
     size_t m_BufferStart = 0;
     size_t m_BufferBytes = 0;
 
@@ -154,21 +163,18 @@ private:
         if (command[0] == "HEY") {
             return true;
         }
-        if (tryRunHandler(command)) {
-            return true;
-        }
 
-        throw BadCommandError();
-    }
-
-    bool tryRunHandler(Command &command)
-    {
         try {
+            std::lock_guard<std::mutex> guard(*m_CommandHandlersMutex);
             CommandHandler &handler = m_CommandHandlers.at(command[0]);
-            handler(*this, command);
+
+            // handler will be nullptr if it has been removed
+            if (handler) {
+                handler(*this, command);
+            }
             return true;
         } catch (std::out_of_range &) {
-            return false;
+            throw BadCommandError();
         }
     }
 

--- a/net/connection.h
+++ b/net/connection.h
@@ -88,17 +88,12 @@ public:
      * \brief Add a handler for a specified type of command
      *
      * e.g. if it's an IMG command, it should be handled by Video::NetSource.
+     * Set to nullptr to disable and ignore these commands.
      */
-    void addCommandHandler(const std::string &commandName, const CommandHandler handler)
+    void setCommandHandler(const std::string &commandName, const CommandHandler handler)
     {
         std::lock_guard<std::mutex> guard(*m_CommandHandlersMutex);
         m_CommandHandlers.emplace(commandName, handler);
-    }
-
-    void removeCommandHandler(const std::string &commandName)
-    {
-        std::lock_guard<std::mutex> guard(*m_CommandHandlersMutex);
-        m_CommandHandlers[commandName] = nullptr;
     }
 
     //! Read a specified number of bytes into a buffer

--- a/net/connection.h
+++ b/net/connection.h
@@ -116,7 +116,7 @@ public:
 
         // keep reading from socket until we have enough bytes
         while (length > 0) {
-            size_t nbytes = m_Socket.read(buffer, length);
+            size_t nbytes = m_Socket.read(cbuffer, length);
             cbuffer += nbytes;
             length -= nbytes;
         }

--- a/os/net.h
+++ b/os/net.h
@@ -128,6 +128,7 @@ private:
     }
 #else
     static void initialise() {}
+    WindowsNetworking() = delete;
 #endif
 }; // WindowsNetworking
 

--- a/robots/norbot.h
+++ b/robots/norbot.h
@@ -32,6 +32,7 @@ public:
     virtual ~Norbot() override
     {
         stopMoving();
+        stopReadingFromNetwork();
     }
 
     virtual void tank(float left, float right) override

--- a/robots/surveyor.h
+++ b/robots/surveyor.h
@@ -55,6 +55,7 @@ public:
     virtual ~Surveyor() override
     {
         stopMoving();
+        stopReadingFromNetwork();
 
         if (m_Socket > 0) {
             close(m_Socket);

--- a/robots/tank.h
+++ b/robots/tank.h
@@ -67,7 +67,7 @@ public:
     void readFromNetwork(Net::Connection &connection)
     {
         // handle incoming TNK commands
-        connection.addCommandHandler("TNK",
+        connection.setCommandHandler("TNK",
             [this](Net::Connection &connection, const Net::Command &command) {
                 onCommandReceived(connection, command);
             });
@@ -78,7 +78,8 @@ public:
     void stopReadingFromNetwork()
     {
         if (m_Connection) {
-            m_Connection->removeCommandHandler("TNK");
+            // Ignore TNK commands
+            m_Connection->setCommandHandler("TNK", nullptr);
         }
     }
 

--- a/robots/tank.h
+++ b/robots/tank.h
@@ -67,12 +67,23 @@ public:
     void readFromNetwork(Net::Connection &connection)
     {
         // handle incoming TNK commands
-        connection.addCommandHandler("TNK", [this](Net::Connection &connection, const Net::Command &command) {
-            onCommandReceived(connection, command);
-        });
+        connection.addCommandHandler("TNK",
+            [this](Net::Connection &connection, const Net::Command &command) {
+                onCommandReceived(connection, command);
+            });
+
+        m_Connection = &connection;
+    }
+
+    void stopReadingFromNetwork()
+    {
+        if (m_Connection) {
+            m_Connection->removeCommandHandler("TNK");
+        }
     }
 
 private:
+    Net::Connection *m_Connection = nullptr;
     float m_X = 0;
     float m_Y = 0;
 

--- a/robots/tank_netsink.h
+++ b/robots/tank_netsink.h
@@ -21,7 +21,12 @@ public:
     {
         try {
             stopMoving();
-        } catch (...) {}
+        } catch (OS::Net::NetworkError &e) {
+            std::cerr << "Warning: Caught exception while trying to send command: "
+                      << e.what() << std::endl;
+        } catch (Net::SocketClosedError &) {
+            // Socket has already been cleanly closed
+        }
 
         stopReadingFromNetwork();
     }

--- a/robots/tank_netsink.h
+++ b/robots/tank_netsink.h
@@ -17,8 +17,17 @@ public:
       : m_Connection(connection)
     {}
 
-    /* Motor command: send TNK command over TCP */
-    void tank(float left, float right) override
+    virtual ~TankNetSink()
+    {
+        try {
+            stopMoving();
+        } catch (...) {}
+
+        stopReadingFromNetwork();
+    }
+
+    //! Motor command: send TNK command over TCP
+    virtual void tank(float left, float right) override
     {
         BOB_ASSERT(left >= -1.f && left <= 1.f);
         BOB_ASSERT(right >= -1.f && right <= 1.f);
@@ -30,7 +39,7 @@ public:
 
         // send steering command
         m_Connection.getSocketWriter().send("TNK " + std::to_string(left) + " " +
-                                      std::to_string(right) + "\n");
+                                            std::to_string(right) + "\n");
 
         // store current left/right values to compare next time
         m_OldLeft = left;

--- a/video/netsink.h
+++ b/video/netsink.h
@@ -42,7 +42,7 @@ public:
       , m_Input(&input)
     {
         // handle incoming IMG commands
-        m_Connection.addCommandHandler("IMG",
+        m_Connection.setCommandHandler("IMG",
                                        [this](Net::Connection &, const Net::Command &command) {
                                            onCommandReceivedAsync(command);
                                        });
@@ -62,7 +62,7 @@ public:
       , m_Input(nullptr)
     {
         // handle incoming IMG commands
-        m_Connection.addCommandHandler("IMG",
+        m_Connection.setCommandHandler("IMG",
                                        [this](Net::Connection &, const Net::Command &command) {
                                            onCommandReceivedSync(command);
                                        });
@@ -70,7 +70,8 @@ public:
 
     virtual ~NetSink()
     {
-        m_Connection.removeCommandHandler("IMG");
+        // Ignore IMG commands
+        m_Connection.setCommandHandler("IMG", nullptr);
 
         m_DoRun = false;
         if (m_Thread.joinable()) {

--- a/video/netsink.h
+++ b/video/netsink.h
@@ -43,7 +43,7 @@ public:
     {
         // handle incoming IMG commands
         m_Connection.addCommandHandler("IMG",
-                                       [this](Net::Connection &, Net::Command &command) {
+                                       [this](Net::Connection &, const Net::Command &command) {
                                            onCommandReceivedAsync(command);
                                        });
     }
@@ -63,7 +63,7 @@ public:
     {
         // handle incoming IMG commands
         m_Connection.addCommandHandler("IMG",
-                                       [this](Net::Connection &, Net::Command &command) {
+                                       [this](Net::Connection &, const Net::Command &command) {
                                            onCommandReceivedSync(command);
                                        });
     }

--- a/video/netsink.h
+++ b/video/netsink.h
@@ -43,7 +43,7 @@ public:
     {
         // handle incoming IMG commands
         m_Connection.addCommandHandler("IMG",
-                                       [this](auto &, auto &command) {
+                                       [this](Net::Connection &, Net::Command &command) {
                                            onCommandReceivedAsync(command);
                                        });
     }
@@ -63,7 +63,7 @@ public:
     {
         // handle incoming IMG commands
         m_Connection.addCommandHandler("IMG",
-                                       [this](auto &, auto &command) {
+                                       [this](Net::Connection &, Net::Command &command) {
                                            onCommandReceivedSync(command);
                                        });
     }

--- a/video/netsink.h
+++ b/video/netsink.h
@@ -43,9 +43,9 @@ public:
     {
         // handle incoming IMG commands
         m_Connection.addCommandHandler("IMG",
-                                 [this](Net::Connection &, const Net::Command &command) {
-                                     onCommandReceivedAsync(command);
-                                 });
+                                       [this](auto &, auto &command) {
+                                           onCommandReceivedAsync(command);
+                                       });
     }
 
     /*!
@@ -63,13 +63,15 @@ public:
     {
         // handle incoming IMG commands
         m_Connection.addCommandHandler("IMG",
-                                 [this](Net::Connection &, const Net::Command &command) {
-                                     onCommandReceivedSync(command);
-                                 });
+                                       [this](auto &, auto &command) {
+                                           onCommandReceivedSync(command);
+                                       });
     }
 
     virtual ~NetSink()
     {
+        m_Connection.removeCommandHandler("IMG");
+
         m_DoRun = false;
         if (m_Thread.joinable()) {
             m_Thread.join();

--- a/video/netsource.h
+++ b/video/netsource.h
@@ -32,7 +32,7 @@ public:
       : m_Connection(connection)
     {
         // Handle incoming IMG commands
-        connection.addCommandHandler("IMG", [this](Net::Connection &connection, const Net::Command &command) {
+        connection.setCommandHandler("IMG", [this](Net::Connection &connection, const Net::Command &command) {
             onCommandReceived(connection, command);
         });
 
@@ -42,7 +42,8 @@ public:
 
     virtual ~NetSource() override
     {
-        m_Connection.removeCommandHandler("IMG");
+        // Ignore IMG commands
+        m_Connection.setCommandHandler("IMG", nullptr);
     }
 
     virtual std::string getCameraName() const override


### PR DESCRIPTION
This PR is mostly to fix a silly bug I introduced in my haste to merge the other PR :-/ (I broke reading frames over the network).

I've also added a mechanism for removing network command handlers, mostly for when we're destroying an object and don't want the ``Connection`` to keep trying to call into the destroyed object (which was causing weird segfaults etc. when exiting programs).