### PR TITLE
Small Ardin MB fixes

### DIFF
--- a/examples/perfect_memory/perfect_memory_test.cc
+++ b/examples/perfect_memory/perfect_memory_test.cc
@@ -87,7 +87,7 @@ main()
     {
         std::cout << std::endl << "Testing with HOG..." << std::endl;
 
-        PerfectMemoryRotater<PerfectMemoryStore::HOG<>> pm(imSize);
+        PerfectMemoryRotater<PerfectMemoryStore::HOG<>> pm(imSize, cv::Size(10, 10), 8);
         trainRoute(pm);
 
         // Time testing phase

--- a/navigation/perfect_memory.h
+++ b/navigation/perfect_memory.h
@@ -37,9 +37,10 @@ template<typename Store = PerfectMemoryStore::RawImage<>>
 class PerfectMemory : public VisualNavigationBase
 {
 public:
-    PerfectMemory(const cv::Size &unwrapRes)
+    template<class... Ts>
+    PerfectMemory(const cv::Size &unwrapRes, Ts &&... args)
       : VisualNavigationBase(unwrapRes)
-      , m_Store(unwrapRes)
+      , m_Store(unwrapRes, std::forward<Ts>(args)...)
     {}
 
     //------------------------------------------------------------------------
@@ -125,7 +126,9 @@ template<typename Store = PerfectMemoryStore::RawImage<>, typename RIDFProcessor
 class PerfectMemoryRotater : public PerfectMemory<Store>
 {
 public:
-    PerfectMemoryRotater(const cv::Size unwrapRes /**TODO*** forward other parameters*/) : PerfectMemory<Store>(unwrapRes)
+    template<class... Ts>
+    PerfectMemoryRotater(const cv::Size unwrapRes, Ts &&... args)
+    :   PerfectMemory<Store>(unwrapRes, std::forward<Ts>(args)...)
     {
     }
     /*!

--- a/navigation/perfect_memory_store_hog.h
+++ b/navigation/perfect_memory_store_hog.h
@@ -28,12 +28,12 @@ template<typename Differencer = AbsDiff>
 class HOG
 {
 public:
-    HOG(const cv::Size unwrapRes, const cv::Size &blockSize, int numOrientations)
+    HOG(const cv::Size &unwrapRes, const cv::Size &blockSize, int numOrientations)
     :   HOG(unwrapRes, blockSize, blockSize, numOrientations)
     {
     }
 
-    HOG(const cv::Size unwrapRes, const cv::Size &blockSize, const cv::Size &blockStride, int numOrientations)
+    HOG(const cv::Size &unwrapRes, const cv::Size &blockSize, const cv::Size &blockStride, int numOrientations)
     :   m_HOGDescriptorSize(unwrapRes.width * unwrapRes.height *
                             numOrientations / (blockSize.width * blockSize.height)),
         m_Differencer(m_HOGDescriptorSize)

--- a/navigation/perfect_memory_store_hog.h
+++ b/navigation/perfect_memory_store_hog.h
@@ -28,21 +28,19 @@ template<typename Differencer = AbsDiff>
 class HOG
 {
 public:
-    HOG(const cv::Size unwrapRes,
-                     const int HOGPixelsPerCell = 10,
-                     int HOGOrientations = 8)
+    HOG(const cv::Size unwrapRes, int hogCellWidth = 10, int hogCellHeight = 10, int hogOrientations = 8)
       : m_HOGDescriptorSize(unwrapRes.width * unwrapRes.height *
-                            HOGOrientations / (HOGPixelsPerCell * HOGPixelsPerCell))
+                            hogOrientations / (hogCellWidth * hogCellHeight))
       , m_Differencer(m_HOGDescriptorSize)
     {
         std::cout << "Creating perfect memory for HOG features" << std::endl;
 
         // Configure HOG features
         m_HOG.winSize = unwrapRes;
-        m_HOG.blockSize = cv::Size(HOGPixelsPerCell, HOGPixelsPerCell);
+        m_HOG.blockSize = cv::Size(hogCellWidth, hogCellHeight);
         m_HOG.blockStride = m_HOG.blockSize;
         m_HOG.cellSize = m_HOG.blockSize;
-        m_HOG.nbins = HOGOrientations;
+        m_HOG.nbins = hogOrientations;
     }
 
     //------------------------------------------------------------------------

--- a/navigation/perfect_memory_store_hog.h
+++ b/navigation/perfect_memory_store_hog.h
@@ -28,19 +28,24 @@ template<typename Differencer = AbsDiff>
 class HOG
 {
 public:
-    HOG(const cv::Size unwrapRes, int hogCellWidth = 10, int hogCellHeight = 10, int hogOrientations = 8)
-      : m_HOGDescriptorSize(unwrapRes.width * unwrapRes.height *
-                            hogOrientations / (hogCellWidth * hogCellHeight))
-      , m_Differencer(m_HOGDescriptorSize)
+    HOG(const cv::Size unwrapRes, const cv::Size &blockSize, int numOrientations)
+    :   HOG(unwrapRes, blockSize, blockSize, numOrientations)
+    {
+    }
+
+    HOG(const cv::Size unwrapRes, const cv::Size &blockSize, const cv::Size &blockStride, int numOrientations)
+    :   m_HOGDescriptorSize(unwrapRes.width * unwrapRes.height *
+                            numOrientations / (blockSize.width * blockSize.height)),
+        m_Differencer(m_HOGDescriptorSize)
     {
         std::cout << "Creating perfect memory for HOG features" << std::endl;
 
         // Configure HOG features
         m_HOG.winSize = unwrapRes;
-        m_HOG.blockSize = cv::Size(hogCellWidth, hogCellHeight);
-        m_HOG.blockStride = m_HOG.blockSize;
-        m_HOG.cellSize = m_HOG.blockSize;
-        m_HOG.nbins = hogOrientations;
+        m_HOG.blockSize = blockSize;
+        m_HOG.blockStride = blockStride;
+        m_HOG.cellSize = blockSize;
+        m_HOG.nbins = numOrientations;
     }
 
     //------------------------------------------------------------------------

--- a/navigation/perfect_memory_store_hog.h
+++ b/navigation/perfect_memory_store_hog.h
@@ -20,6 +20,9 @@ namespace BoBRobotics {
 namespace Navigation {
 namespace PerfectMemoryStore {
 
+    /*numOrientations*
+        ((unwrapRes.width - blockSize.width)/blockStride.width + 1)*
+        ((unwrapRes.height - blockSize.height)/blockStride.height + 1);*/
 //------------------------------------------------------------------------
 // BoBRobotics::Navigation::PerfectMemoryStore::HOG
 //------------------------------------------------------------------------
@@ -34,11 +37,10 @@ public:
     }
 
     HOG(const cv::Size &unwrapRes, const cv::Size &blockSize, const cv::Size &blockStride, int numOrientations)
-    :   m_HOGDescriptorSize(unwrapRes.width * unwrapRes.height *
-                            numOrientations / (blockSize.width * blockSize.height)),
+    :   m_HOGDescriptorSize(numOrientations * ((unwrapRes.width - blockSize.width)/blockStride.width + 1) * ((unwrapRes.height - blockSize.height)/blockStride.height + 1)),
         m_Differencer(m_HOGDescriptorSize)
     {
-        std::cout << "Creating perfect memory for HOG features" << std::endl;
+        std::cout << "Creating perfect memory for " << m_HOGDescriptorSize<< " entry HOG features" << std::endl;
 
         // Configure HOG features
         m_HOG.winSize = unwrapRes;

--- a/projects/ardin_mb/mb_memory.cc
+++ b/projects/ardin_mb/mb_memory.cc
@@ -82,6 +82,11 @@ float MBMemory::test(const cv::Mat &image) const
     return (float)numENSpikes / (float)(convertMsToTimesteps(MBParams::presentDurationMs) + convertMsToTimesteps(MBParams::postStimuliDurationMs));
 }
 //----------------------------------------------------------------------------
+void MBMemory::clearMemory()
+{
+    throw std::runtime_error("MBMemory does not currently support clearing");
+}
+//----------------------------------------------------------------------------
 std::tuple<unsigned int, unsigned int, unsigned int> MBMemory::present(const cv::Mat &image, bool train) const
 {
     BOB_ASSERT(image.cols == MBParams::inputWidth);

--- a/projects/ardin_mb/mb_memory.h
+++ b/projects/ardin_mb/mb_memory.h
@@ -26,6 +26,9 @@ public:
     //! Test the algorithm with the specified image
     virtual float test(const cv::Mat &image) const override;
 
+    //! Clear the memory
+    virtual void clearMemory() override;
+
 private:
     std::tuple<unsigned int, unsigned int, unsigned int> present(const cv::Mat &image, bool train) const;
 

--- a/projects/ardin_mb/state_handler.cc
+++ b/projects/ardin_mb/state_handler.cc
@@ -12,6 +12,7 @@
 
 using namespace BoBRobotics;
 using namespace units::literals;
+using namespace units::length;
 
 //----------------------------------------------------------------------------
 // StateHandler


### PR DESCRIPTION
I'm planning on trying to finish off my investigations into HOG features and I found a few things were broken when trying to incorporate them into ant world:
- No way of getting parameters to ``PerfectMemoryStore`` - parameters now get forwarded
- Updated interface to ``VisualNavigationBase`` not reflected in ``MBMemory``