### PR TITLE
Add Parrot's SDK as git submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "third_party/arsdk3/arsdk_manifests"]
+	path = third_party/arsdk3/arsdk_manifests
+	url = https://github.com/Parrot-Developers/arsdk_manifests

--- a/libbebop/Makefile
+++ b/libbebop/Makefile
@@ -27,12 +27,12 @@ TARGET := libbebop.a
 
 all: $(TARGET)
 
-$(TARGET): arsdk3 $(OBJECTS)
+$(TARGET): $(OBJECTS)
 	$(AR) -rcs $@ $(OBJECTS)
 
 -include $(DEPS)
 
-%.o: %.cc %.d
+%.o: %.cc %.d arsdk3
 	$(CXX) $(CXXFLAGS) -c -o $@ $<
 
 %.d: ;

--- a/libbebop/Makefile
+++ b/libbebop/Makefile
@@ -7,7 +7,8 @@ CXXFLAGS+=-Wno-deprecated-declarations -Wno-implicit-fallthrough
 
 # AR SDK
 ifndef ARSDK_ROOT
-$(error Environment variable ARSDK_ROOT must be defined)
+ARSDK_ROOT := ../third_party/arsdk3
+USE_LOCAL_ARSDK := 1
 endif
 AR_STAGING_PATH=$(ARSDK_ROOT)/out/arsdk-native/staging
 CXXFLAGS+=-I$(AR_STAGING_PATH)/usr/include
@@ -20,13 +21,13 @@ SOURCES := bebop.cc video.cc
 OBJECTS := $(SOURCES:.cc=.o)
 DEPS	:= $(SOURCES:.cc=.d)
 
-.PHONY: all clean
+.PHONY: all clean arsdk3
 
 TARGET := libbebop.a
 
 all: $(TARGET)
 
-$(TARGET): $(OBJECTS)
+$(TARGET): arsdk3 $(OBJECTS)
 	$(AR) -rcs $@ $(OBJECTS)
 
 -include $(DEPS)
@@ -38,3 +39,9 @@ $(TARGET): $(OBJECTS)
 
 clean:
 	rm -f $(OBJECTS) $(DEPS) $(TARGET)
+
+arsdk3:
+ifdef USE_LOCAL_ARSDK
+	$(MAKE) -C $(ARSDK_ROOT)
+endif
+	@echo Using ARSDK at: $(ARSDK_ROOT)

--- a/third_party/arsdk3/.gitignore
+++ b/third_party/arsdk3/.gitignore
@@ -1,0 +1,4 @@
+/*
+!/Makefile
+!/arsdk_manifests
+!/.gitignore

--- a/third_party/arsdk3/Makefile
+++ b/third_party/arsdk3/Makefile
@@ -1,17 +1,25 @@
 .PHONY: checkout build
 
 checkout:
+	@# Check out git submodule
 	@git submodule update --init arsdk_manifests
+
+	@# If build.sh doesn't exist, then checkout repo
 ifeq ("$(wildcard build.sh)","")
 	@repo init -u arsdk_manifests --no-clone-bundle --depth=1
 	@repo sync
 	$(MAKE) build
 endif
+
+	@# If target doesn't exist, run build script. Note that this doesn't check
+	@# whether the ARSDK finished building, so if it's half built you should run:
+	@# 	make build
 ifeq ("$(wildcard out/arsdk-native/staging/usr)","")
 	$(MAKE) build
 else
 	@echo ARSDK is already built
 endif
 
+# Build ARSDK with Parrot's script
 build:
 	./build.sh -p arsdk-native -t build-sdk -j

--- a/third_party/arsdk3/Makefile
+++ b/third_party/arsdk3/Makefile
@@ -1,0 +1,16 @@
+.PHONY: checkout build
+
+checkout:
+ifeq ("$(wildcard .repo)","")
+	@repo init -u arsdk_manifests --no-clone-bundle --depth=1
+	@repo sync
+	$(MAKE) build
+endif
+ifeq ("$(wildcard out/arsdk-native/staging/usr)","")
+	$(MAKE) build
+else
+	@echo ARSDK is already built
+endif
+
+build:
+	./build.sh -p arsdk-native -t build-sdk -j

--- a/third_party/arsdk3/Makefile
+++ b/third_party/arsdk3/Makefile
@@ -1,7 +1,8 @@
 .PHONY: checkout build
 
 checkout:
-ifeq ("$(wildcard .repo)","")
+	@git submodule update --init arsdk_manifests
+ifeq ("$(wildcard build.sh)","")
 	@repo init -u arsdk_manifests --no-clone-bundle --depth=1
 	@repo sync
 	$(MAKE) build


### PR DESCRIPTION
This PR adds the SDK as a submodule and automatically builds it when building libbebop. It'll only do this if the ``ARSDK_ROOT`` environment variable isn't set though, so we can keep on using it as before. I just thought it might be an idea to bundle it for when other people want to use the Bebop code.