### PR TITLE
Add support for OpenCV 4

### DIFF
--- a/examples/camera_360/camera_360_test.cc
+++ b/examples/camera_360/camera_360_test.cc
@@ -28,11 +28,11 @@ int main()
     cv::Mat outputImage(unwrapRes, CV_8UC3);
 
     // Create motor
-    cv::namedWindow("Unwrapped", CV_WINDOW_NORMAL);
+    cv::namedWindow("Unwrapped", cv::WINDOW_NORMAL);
     cv::resizeWindow("Unwrapped", unwrapRes.width * outputScale,
                      unwrapRes.height * outputScale);
 
-    cv::namedWindow("Original", CV_WINDOW_NORMAL);
+    cv::namedWindow("Original", cv::WINDOW_NORMAL);
     cv::resizeWindow("Original", cameraRes.width, cameraRes.height);
 
     {

--- a/examples/optical_flow/optical_flow_test.cc
+++ b/examples/optical_flow/optical_flow_test.cc
@@ -52,11 +52,11 @@ int main()
     cv::Mat outputImage(unwrapRes, CV_8UC3);
 
     // Create windows
-    cv::namedWindow("Unwrapped", CV_WINDOW_NORMAL);
+    cv::namedWindow("Unwrapped", cv::WINDOW_NORMAL);
     cv::resizeWindow("Unwrapped", unwrapRes.width * outputScale, unwrapRes.height * outputScale);
-    cv::namedWindow("Original", CV_WINDOW_NORMAL);
+    cv::namedWindow("Original", cv::WINDOW_NORMAL);
     cv::resizeWindow("Original", camRes.width, camRes.height);
-    cv::namedWindow("Optical flow", CV_WINDOW_NORMAL);
+    cv::namedWindow("Optical flow", cv::WINDOW_NORMAL);
     cv::resizeWindow("Optical flow", unwrapRes.width * outputScale, unwrapRes.height * outputScale);
 
     // Build a velocity filter whose preferred angle is going straight ahead
@@ -89,13 +89,13 @@ int main()
                 opticalFlow.render(flowImage, outputScale);
 
                 // Reduce horizontal flow - summing along columns
-                cv::reduce(opticalFlow.getFlowX(), flowXSum, 0, CV_REDUCE_SUM);
+                cv::reduce(opticalFlow.getFlowX(), flowXSum, 0, cv::REDUCE_SUM);
 
                 // Multiply summed flow by filters
                 cv::multiply(flowXSum, velocityFilter, flowXSum);
 
                 // Reduce filtered flow - summing along rows
-                cv::reduce(flowXSum, flowSum, 1, CV_REDUCE_SUM);
+                cv::reduce(flowXSum, flowSum, 1, cv::REDUCE_SUM);
 
                 char textBuffer[256];
                 sprintf(textBuffer, "%f", flowSum.at<float>(0, 0));

--- a/examples/perfect_memory/perfect_memory_test.cc
+++ b/examples/perfect_memory/perfect_memory_test.cc
@@ -94,7 +94,7 @@ main()
         Timer<> t{ "Time taken for testing: " };
 
         // Treat snapshot #10 as test data
-        cv::Mat snap = cv::imread("../../tools/ant_world_db_creator/ant1_route1/image_00010.png", CV_LOAD_IMAGE_GRAYSCALE);
+        cv::Mat snap = cv::imread("../../tools/ant_world_db_creator/ant1_route1/image_00010.png", cv::IMREAD_GRAYSCALE);
         cv::resize(snap, snap, imSize);
         size_t snapshot;
         float difference;

--- a/examples/perfect_memory/plot_ridf.cc
+++ b/examples/perfect_memory/plot_ridf.cc
@@ -15,7 +15,7 @@ main()
     PerfectMemoryRotater<> pm(imSize);
 
     // Load a single snapshot
-    cv::Mat snap = cv::imread("../../tools/ant_world_db_creator/ant1_route1/image_00010.png", CV_LOAD_IMAGE_GRAYSCALE);
+    cv::Mat snap = cv::imread("../../tools/ant_world_db_creator/ant1_route1/image_00010.png", cv::IMREAD_GRAYSCALE);
     cv::resize(snap, snap, imSize);
     pm.train(snap);
 

--- a/examples/see3cam/see3cam_test.cc
+++ b/examples/see3cam/see3cam_test.cc
@@ -80,9 +80,9 @@ int main(int argc, char *argv[])
 
     auto autoExposureMask = cam.createBubblescopeMask(cv::Size(rawWidth, rawHeight));
 
-    cv::namedWindow("Raw", CV_WINDOW_NORMAL);
+    cv::namedWindow("Raw", cv::WINDOW_NORMAL);
     cv::resizeWindow("Raw", rawWidth, rawHeight);
-    cv::namedWindow("Unwrapped", CV_WINDOW_NORMAL);
+    cv::namedWindow("Unwrapped", cv::WINDOW_NORMAL);
     cv::resizeWindow("Unwrapped", unwrapWidth, unwrapHeight);
 
     cv::Mat output(rawHeight, rawWidth, CV_8UC1);

--- a/libantworld/snapshot_processor_ardin.cc
+++ b/libantworld/snapshot_processor_ardin.cc
@@ -75,7 +75,7 @@ void SnapshotProcessorArdin::process(const cv::Mat &snapshot)
     // Finally resample down to final size
     cv::resize(m_IntermediateSnapshotGreyscale, m_FinalSnapshot,
                 cv::Size(m_OutputWidth, m_OutputHeight),
-                0.0, 0.0, CV_INTER_CUBIC);
+                0.0, 0.0, cv::INTER_CUBIC);
 }
 }   // namespace AntWorld
 }   // namespace BoBRobotics

--- a/make_common/bob_robotics.mk
+++ b/make_common/bob_robotics.mk
@@ -51,8 +51,11 @@ endif
 
 # Build with OpenCV
 ifndef NO_OPENCV
-	CXXFLAGS += `pkg-config --cflags opencv`
-	LINK_FLAGS += `pkg-config --libs opencv`
+ifndef OPENCV_PKG_NAME
+	OPENCV_PKG_NAME := opencv
+endif
+	CXXFLAGS += `pkg-config --cflags $(OPENCV_PKG_NAME)`
+	LINK_FLAGS += `pkg-config --libs $(OPENCV_PKG_NAME)`
 endif
 
 ifdef WITH_LIBBEBOP

--- a/projects/stone_cx/simulator.cc
+++ b/projects/stone_cx/simulator.cc
@@ -67,11 +67,11 @@ int main()
 
     initstone_cx();
 
-    cv::namedWindow("Path", CV_WINDOW_NORMAL);
+    cv::namedWindow("Path", cv::WINDOW_NORMAL);
     cv::resizeWindow("Path", pathImageSize, pathImageSize);
     cv::Mat pathImage(pathImageSize, pathImageSize, CV_8UC3, cv::Scalar::all(0));
 
-    cv::namedWindow("Activity", CV_WINDOW_NORMAL);
+    cv::namedWindow("Activity", cv::WINDOW_NORMAL);
     cv::resizeWindow("Activity", activityImageWidth, activityImageHeight);
     cv::moveWindow("Activity", pathImageSize, 0);
     cv::Mat activityImage(activityImageHeight, activityImageWidth, CV_8UC3, cv::Scalar::all(0));

--- a/projects/stone_cx/simulatorReplay.cc
+++ b/projects/stone_cx/simulatorReplay.cc
@@ -68,11 +68,11 @@ int main()
 
     initstone_cx();
 
-    cv::namedWindow("Path", CV_WINDOW_NORMAL);
+    cv::namedWindow("Path", cv::WINDOW_NORMAL);
     cv::resizeWindow("Path", pathImageSize, pathImageSize);
     cv::Mat pathImage(pathImageSize, pathImageSize, CV_8UC3, cv::Scalar::all(0));
 
-    cv::namedWindow("Activity", CV_WINDOW_NORMAL);
+    cv::namedWindow("Activity", cv::WINDOW_NORMAL);
     cv::resizeWindow("Activity", activityImageWidth, activityImageHeight);
     cv::moveWindow("Activity", pathImageSize, 0);
     cv::Mat activityImage(activityImageHeight, activityImageWidth, CV_8UC3, cv::Scalar::all(0));

--- a/projects/stone_cx/simulatorRobot.cc
+++ b/projects/stone_cx/simulatorRobot.cc
@@ -128,7 +128,7 @@ void opticalFlowThreadFunc(int cameraDevice, std::atomic<bool> &shouldQuit, std:
         if(!capture.read(rgbInput)) {
             return;
         }
-        cv::cvtColor(rgbInput, greyscaleInput, CV_BGR2GRAY);
+        cv::cvtColor(rgbInput, greyscaleInput, cv::COLOR_BGR2GRAY);
 #endif
 
         // Unwrap
@@ -137,13 +137,13 @@ void opticalFlowThreadFunc(int cameraDevice, std::atomic<bool> &shouldQuit, std:
         // Calculate optical flow
         if(opticalFlow.calculate(outputImage)) {
             // Reduce horizontal flow - summing along columns
-            cv::reduce(opticalFlow.getFlowX(), flowXSum, 0, CV_REDUCE_SUM);
+            cv::reduce(opticalFlow.getFlowX(), flowXSum, 0, cv::REDUCE_SUM);
 
             // Multiply summed flow by filters
             cv::multiply(flowXSum, velocityFilter, flowXSum);
 
             // Reduce filtered flow - summing along rows
-            cv::reduce(flowXSum, flowSum, 1, CV_REDUCE_SUM);
+            cv::reduce(flowXSum, flowSum, 1, cv::REDUCE_SUM);
 
             // Filter speed and set atomic
             prevSpeed = (alpha * flowSum.at<float>(0, 0)) + ((1.0f - alpha) * prevSpeed);

--- a/tools/unwrapfile/unwrapfile.cc
+++ b/tools/unwrapfile/unwrapfile.cc
@@ -31,7 +31,7 @@ enum class FileType {
 
 void saveMaxQualityJPG(const std::string &filename, const cv::Mat &image)
 {
-    std::vector<int> params{CV_IMWRITE_JPEG_QUALITY, 100};
+    static std::vector<int> params{cv::IMWRITE_JPEG_QUALITY, 100};
     cv::imwrite(filename, image, params);
 }
 
@@ -41,7 +41,7 @@ void unwrapJPEG(const char *filepathRaw, const cv::Size &unwrappedResolution, co
     const filesystem::path filepath(filepathRaw);
 
     // read image into memory
-    cv::Mat im = cv::imread(filepath.str(), CV_LOAD_IMAGE_COLOR);
+    cv::Mat im = cv::imread(filepath.str(), cv::IMREAD_COLOR);
 
     // matrix to store unwrapped image
     cv::Mat imunwrap(unwrappedResolution, im.type());
@@ -84,7 +84,7 @@ void unwrapMP4(const char *filepathRaw, bool copysound, const cv::Size &unwrappe
 
     // start writing to file
     std::cout << "Saving video to " << outfilename << "..." << std::endl;
-    cv::VideoWriter writer(tempfilename.str(), 0x21, cap.get(CV_CAP_PROP_FPS), unwrappedResolution);
+    cv::VideoWriter writer(tempfilename.str(), 0x21, cap.get(cv::CAP_PROP_FPS), unwrappedResolution);
     if (!writer.isOpened()) {
         std::cerr << "Error: Could not open file for writing" << std::endl;
         return;

--- a/video/display.h
+++ b/video/display.h
@@ -88,7 +88,7 @@ public:
     //! Return true if the display window is open
     bool isOpen() const
     {
-        return cvGetWindowHandle(WindowName) != nullptr;
+        return cv::getWindowProperty(WindowName, cv::WND_PROP_VISIBLE);
     }
 
     /*!

--- a/video/input.h
+++ b/video/input.h
@@ -64,7 +64,7 @@ public:
             outFrame.create(m_IntermediateFrame.size(), CV_8UC1);
 
             // Convert intermediate frame to greyscale
-            cv::cvtColor(m_IntermediateFrame, outFrame, CV_BGR2GRAY);
+            cv::cvtColor(m_IntermediateFrame, outFrame, cv::COLOR_BGR2GRAY);
             return true;
         }
         else {

--- a/video/see3cam_cu40.h
+++ b/video/see3cam_cu40.h
@@ -427,14 +427,14 @@ public:
                    cv::Point(centreXPixel, centreYPixel),
                    outerPixel,
                    cv::Scalar::all(255),
-                   CV_FILLED);
+                   cv::FILLED);
 
         // Draw inner black circle
         cv::circle(mask,
                    cv::Point(centreXPixel, centreYPixel),
                    innerPixel,
                    cv::Scalar::all(0),
-                   CV_FILLED);
+                   cv::FILLED);
 
         return mask;
     }


### PR DESCRIPTION
So OpenCV 4 is out and Arch has already upgraded, which predictably means that BoB robotics stuff won't compile for me any more.

Thankfully it seems like they haven't introduced any breaking changes that I can tell, but they have removed large chunks of the old C API, which notably means that all the ``CV_*`` constants we're using don't exist any more and you're supposed to use their enums instead (which also exist in OpenCV 3).

I've made these changes and now everything seems to work for me. Hopefully it shouldn't break anything for OpenCV 3 either.