### PR TITLE
Keep track of when Vicon packets were received (fixes #79)

### DIFF
--- a/common/stopwatch.h
+++ b/common/stopwatch.h
@@ -1,0 +1,39 @@
+#pragma once
+
+// Standard C++ includes
+#include <chrono>
+
+namespace BoBRobotics {
+class Stopwatch
+{
+public:
+    using TimePoint = std::chrono::high_resolution_clock::time_point;
+    using Duration = std::chrono::high_resolution_clock::duration;
+
+    void start()
+    {
+        m_StartTime = now();
+    }
+
+    Duration elapsed() const
+    {
+        return now() - m_StartTime;
+    }
+
+    Duration lap()
+    {
+        const TimePoint currentTime = now();
+        const Duration elapsed = currentTime - m_StartTime;
+        m_StartTime = currentTime;
+        return elapsed;
+    }
+
+    static TimePoint now()
+    {
+        return std::chrono::high_resolution_clock::now();
+    }
+
+private:
+    TimePoint m_StartTime;
+}; // Stopwatch
+} // BoBRobotics

--- a/examples/vicon/vicon_plot_test.cc
+++ b/examples/vicon/vicon_plot_test.cc
@@ -35,9 +35,19 @@ main()
         return EXIT_FAILURE;
     }
 
+    bool warningGiven = false;
     do {
         plt::figure(1);
-        plotAgent(vicon.getObjectData(0), { -2500, 2500 }, { -2500, 2500 });
+        const auto data = vicon.getObjectData(0);
+        plotAgent(data, { -2500, 2500 }, { -2500, 2500 });
+        if (data.getElapsedTime() > 500ms) {
+            if (!warningGiven) {
+                std::cerr << "Warning: Object is out of range" << std::endl;
+                warningGiven = true;
+            }
+        } else {
+            warningGiven = false;
+        }
         plt::pause(0.025);
     } while (plt::fignum_exists(1));
 

--- a/examples/vicon/vicon_plot_test.cc
+++ b/examples/vicon/vicon_plot_test.cc
@@ -40,7 +40,7 @@ main()
         plt::figure(1);
         const auto data = vicon.getObjectData(0);
         plotAgent(data, { -2500, 2500 }, { -2500, 2500 });
-        if (data.getElapsedTime() > 500ms) {
+        if (vicon.timeSinceLastPacket(0) > 500ms) {
             if (!warningGiven) {
                 std::cerr << "Warning: Object is out of range" << std::endl;
                 warningGiven = true;

--- a/examples/vicon/vicon_plot_test.cc
+++ b/examples/vicon/vicon_plot_test.cc
@@ -40,7 +40,7 @@ main()
         plt::figure(1);
         const auto data = vicon.getObjectData(0);
         plotAgent(data, { -2500, 2500 }, { -2500, 2500 });
-        if (vicon.timeSinceLastPacket(0) > 500ms) {
+        if (data.timeSinceReceived() > 500ms) {
             if (!warningGiven) {
                 std::cerr << "Warning: Object is out of range" << std::endl;
                 warningGiven = true;

--- a/vicon/udp.h
+++ b/vicon/udp.h
@@ -3,6 +3,7 @@
 // BoB robotics includes
 #include "../common/assert.h"
 #include "../common/pose.h"
+#include "../common/stopwatch.h"
 #include "../os/net.h"
 
 // Standard C++ includes
@@ -12,6 +13,7 @@
 #include <mutex>
 #include <string>
 #include <thread>
+#include <utility>
 #include <vector>
 
 namespace BoBRobotics
@@ -55,6 +57,16 @@ public:
         m_Attitude[2] = roll;
     }
 
+    auto getElapsedTime() const
+    {
+        return m_ElapsedTime;
+    }
+
+    void setElapsedTime(const Stopwatch::Duration elapsed)
+    {
+        m_ElapsedTime = elapsed;
+    }
+
     uint32_t getFrameNumber() const
     {
         return m_FrameNumber;
@@ -77,6 +89,7 @@ private:
     // Members
     //----------------------------------------------------------------------------
     uint32_t m_FrameNumber;
+    Stopwatch::Duration m_ElapsedTime;
     Vector3<millimeter_t> m_Position;
     Vector3<radian_t> m_Attitude;
 };
@@ -222,7 +235,9 @@ public:
     {
         std::lock_guard<std::mutex> guard(m_ObjectDataMutex);
         if(id < m_ObjectData.size()) {
-            return m_ObjectData[id];
+            auto data = m_ObjectData[id].first;
+            data.setElapsedTime(m_ObjectData[id].second.elapsed());
+            return data;
         }
         else {
             throw std::runtime_error("Invalid object id: " + std::to_string(id));
@@ -241,9 +256,10 @@ private:
         std::lock_guard<std::mutex> guard(m_ObjectDataMutex);
 
         // If no object data structure has been created for this ID, add one
-        if(id >= m_ObjectData.size()) {
+        if (id >= m_ObjectData.size()) {
             m_ObjectData.resize(id + 1);
         }
+        m_ObjectData[id].second.start();
 
         /*
          * Update object data with position and attitude.
@@ -254,13 +270,13 @@ private:
          */
         using namespace units::length;
         using namespace units::angle;
-        m_ObjectData[id].update(frameNumber,
-                                millimeter_t(position[0]),
-                                millimeter_t(position[1]),
-                                millimeter_t(position[2]),
-                                radian_t(attitude[2]),
-                                radian_t(attitude[0]),
-                                radian_t(attitude[1]));
+        m_ObjectData[id].first.update(frameNumber,
+                                      millimeter_t(position[0]),
+                                      millimeter_t(position[1]),
+                                      millimeter_t(position[2]),
+                                      radian_t(attitude[2]),
+                                      radian_t(attitude[0]),
+                                      radian_t(attitude[1]));
     }
 
     void readThread(int socket)
@@ -335,7 +351,7 @@ private:
     void *m_ReadUserData;
 
     std::mutex m_ObjectDataMutex;
-    std::vector<ObjectDataType> m_ObjectData;
+    std::vector<std::pair<ObjectDataType, Stopwatch>> m_ObjectData;
 };
 } // namespace Vicon
 } // BoBRobotics

--- a/vicon/udp.h
+++ b/vicon/udp.h
@@ -226,7 +226,7 @@ public:
         return m_ObjectData.at(id).first;
     }
 
-    auto timeSinceLastPacket(unsigned int objectId) const
+    auto timeSinceLastPacket(unsigned int objectId)
     {
         std::lock_guard<std::mutex> guard(m_ObjectDataMutex);
         return m_ObjectData.at(objectId).second.elapsed();

--- a/vicon/udp.h
+++ b/vicon/udp.h
@@ -57,16 +57,6 @@ public:
         m_Attitude[2] = roll;
     }
 
-    auto getElapsedTime() const
-    {
-        return m_ElapsedTime;
-    }
-
-    void setElapsedTime(const Stopwatch::Duration elapsed)
-    {
-        m_ElapsedTime = elapsed;
-    }
-
     uint32_t getFrameNumber() const
     {
         return m_FrameNumber;
@@ -89,7 +79,6 @@ private:
     // Members
     //----------------------------------------------------------------------------
     uint32_t m_FrameNumber;
-    Stopwatch::Duration m_ElapsedTime;
     Vector3<millimeter_t> m_Position;
     Vector3<radian_t> m_Attitude;
 };
@@ -234,14 +223,13 @@ public:
     ObjectDataType getObjectData(unsigned int id)
     {
         std::lock_guard<std::mutex> guard(m_ObjectDataMutex);
-        if(id < m_ObjectData.size()) {
-            auto data = m_ObjectData[id].first;
-            data.setElapsedTime(m_ObjectData[id].second.elapsed());
-            return data;
-        }
-        else {
-            throw std::runtime_error("Invalid object id: " + std::to_string(id));
-        }
+        return m_ObjectData.at(id).first;
+    }
+
+    auto timeSinceLastPacket(unsigned int objectId) const
+    {
+        std::lock_guard<std::mutex> guard(m_ObjectDataMutex);
+        return m_ObjectData.at(objectId).second.elapsed();
     }
 
 private:


### PR DESCRIPTION
This adds a ``getElapsedTime()`` method to the ``ObjectData`` class so you can e.g. stop a robot if the positional data is too old.

I've updated one of the examples to show this feature.