### PR TITLE
Fix for gantry code + misc tweaks

### DIFF
--- a/common/main.h
+++ b/common/main.h
@@ -25,12 +25,12 @@ main(int argc, char **argv)
     } catch (std::exception &e) {
         // Windows doesn't print exception details by default
         std::cerr << "Uncaught exception: " << e.what() << std::endl;
-#ifndef DEBUG
+#ifdef _DEBUG
+        throw;
+#else
         // There's no point telling Windows the program has crashed
         return EXIT_FAILURE;
-#else
-        throw;
-#endif // !DEBUG
+#endif // !_DEBUG
 #endif // _WIN32
     } catch (...) {
         // Rethrow the caught exception

--- a/make_common/bob_robotics.mk
+++ b/make_common/bob_robotics.mk
@@ -13,6 +13,9 @@ CPP_STANDARD ?= c++14
 # Build flags
 CXXFLAGS += -std=$(CPP_STANDARD) -Wall -Wpedantic -Wextra -MMD -MP
 
+# Silence warning in given by third_party/tinydir.h
+CXXFLAGS += -Wno-restrict
+
 # Include the root BoB robotics folder
 CURRENT_DIR := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
 BOB_ROBOTICS_ROOT := $(CURRENT_DIR)/..

--- a/make_common/bob_robotics.mk
+++ b/make_common/bob_robotics.mk
@@ -13,9 +13,6 @@ CPP_STANDARD ?= c++14
 # Build flags
 CXXFLAGS += -std=$(CPP_STANDARD) -Wall -Wpedantic -Wextra -MMD -MP
 
-# Silence warning in given by third_party/tinydir.h
-CXXFLAGS += -Wno-restrict
-
 # Include the root BoB robotics folder
 CURRENT_DIR := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
 BOB_ROBOTICS_ROOT := $(CURRENT_DIR)/..

--- a/navigation/image_database.h
+++ b/navigation/image_database.h
@@ -561,7 +561,7 @@ private:
         }
     }
 
-    void writeImage(const std::string &filename, const cv::Mat &image)
+    void writeImage(const std::string &filename, const cv::Mat &image) const
     {
         const filesystem::path path = m_Path / filename;
         BOB_ASSERT(!path.exists()); // Don't overwrite data by default!

--- a/navigation/image_database.h
+++ b/navigation/image_database.h
@@ -276,28 +276,31 @@ public:
         }
 
         //! Save a new image taken at the specified pose
-        void record(const Vector3<millimeter_t> &position, degree_t heading,
-                    const cv::Mat &image)
+        void record(const Vector3<millimeter_t> &position, degree_t heading, const cv::Mat &image)
         {
             const std::string filename = ImageDatabase::getFilename(size(), getImageFormat());
             addEntry(filename, image, position, heading);
         }
     };
 
-    ImageDatabase(const char *databasePath)
-      : ImageDatabase(filesystem::path(databasePath))
+    ImageDatabase(const char *databasePath, bool overwrite = false)
+      : ImageDatabase(filesystem::path(databasePath), overwrite)
     {}
 
-    ImageDatabase(const std::string &databasePath)
-      : ImageDatabase(filesystem::path(databasePath))
+    ImageDatabase(const std::string &databasePath, bool overwrite = false)
+      : ImageDatabase(filesystem::path(databasePath), overwrite)
     {}
 
-    ImageDatabase(const filesystem::path &databasePath)
+    ImageDatabase(const filesystem::path &databasePath, bool overwrite = false)
       : m_Path(databasePath)
     {
-        const auto entriesPath = m_Path / EntriesFilename;
+        if (overwrite && databasePath.exists()) {
+            std::cerr << "Warning: Database already exists; overwriting" << std::endl;
+            filesystem::remove_all(databasePath);
+		}
 
         // If we don't have any entries, it's an empty database
+        const auto entriesPath = m_Path / EntriesFilename;
         if (!entriesPath.exists()) {
             // Make sure we have a directory to save into
             filesystem::create_directory(m_Path);

--- a/robots/gantry.h
+++ b/robots/gantry.h
@@ -58,7 +58,7 @@ public:
         }
     }
 
-    ~Gantry()
+    ~Gantry() noexcept
     {
         // Stop the gantry moving
         stopMoving();
@@ -101,13 +101,13 @@ public:
      * Home position is (0, 0, 0). The gantry needs to be homed before use so that it
      * can reset its estimate of its position. This function does not block.
      */
-    void home(BYTE axis = XYZ_Axis)
+    void home(BYTE axis = XYZ_Axis) const
     {
         checkError(P1240MotHome(m_BoardId, axis), "Could not home axis");
     }
 
     //! Check if either of the emergency buttons are pressed down
-    bool isEmergencyButtonPressed()
+    bool isEmergencyButtonPressed() const
     {
         DWORD ret;
         checkError(P1240MotRdReg(m_BoardId, 1, RR2, &ret), "Could not read emergency button flag");
@@ -116,7 +116,7 @@ public:
 
     //! Get the current position of the gantry in the arena
     template<class LengthUnit = millimeter_t>
-    Vector3<LengthUnit> getPosition()
+    Vector3<LengthUnit> getPosition() const
     {
         // Request position from card
         Vector3<LONG> pulses;
@@ -172,13 +172,13 @@ public:
     }
 
     //! Stop the gantry moving, optionally specifying a specific axis
-    void stopMoving(BYTE axis = XYZ_Axis) noexcept
+    void stopMoving(BYTE axis = XYZ_Axis) const noexcept
     {
         P1240MotStop(m_BoardId, axis, axis * SlowStop);
     }
 
     //! Check if the gantry is moving
-    bool isMoving(BYTE axis = XYZ_Axis)
+    bool isMoving(BYTE axis = XYZ_Axis) const
     {
         // Indicate whether specified axis/axes busy
         LRESULT res = P1240MotAxisBusy(m_BoardId, axis);
@@ -195,7 +195,7 @@ public:
     }
 
     //! Wait until the gantry has stopped moving
-    void waitToStopMoving(BYTE axis = XYZ_Axis)
+    void waitToStopMoving(BYTE axis = XYZ_Axis) const
     {
         // Repeatedly poll card to check whether gantry is moving
         while (isMoving(axis)) {
@@ -225,13 +225,13 @@ private:
     // These are the gantry's upper x, y and z limits (i.e. the size of the "arena")
     static constexpr Vector3<millimeter_t> Limits = { 2996_mm, 1793_mm, 1203_mm };
 
-    void close() noexcept
+    void close() const noexcept
     {
         // Close PCI device
         P1240MotDevClose(m_BoardId);
     }
 
-    inline void checkEmergencyButton()
+    inline void checkEmergencyButton() const
     {
         if (isEmergencyButtonPressed()) {
             throw std::runtime_error("Gantry error: Emergency button is pressed");

--- a/third_party/path.h
+++ b/third_party/path.h
@@ -344,7 +344,9 @@ inline bool create_directory(const path& p) {
 inline void copy_file(const filesystem::path &from, const filesystem::path &to)
 {
     std::ifstream ifs(from.str());
+    BOB_ASSERT(ifs.good());
     std::ofstream ofs(to.str());
+    BOB_ASSERT(ofs.good());
     ofs << ifs.rdbuf();
 }
 

--- a/third_party/path.h
+++ b/third_party/path.h
@@ -418,7 +418,12 @@ remove_all(const path &path)
 
         // For reading contents of directory
         tinydir_dir dir;
-        tinydir_open(&dir, path.wstr().c_str());
+#ifdef _WIN32
+        const auto path_cstr = path.wstr().c_str();
+#else
+        const auto path_cstr = path.str().c_str();
+#endif
+        tinydir_open(&dir, path_cstr);
         for (; dir.has_next; tinydir_next(&dir)) {
             tinydir_file file;
             tinydir_readfile(&dir, &file);
@@ -442,11 +447,11 @@ remove_all(const path &path)
 
         // Remove directory
 #ifdef _WIN32
-        BOB_ASSERT(::RemoveDirectoryW(path.wstr().c_str()));
+        BOB_ASSERT(::RemoveDirectoryW(path_cstr);
 #else
-        const int ret = ::rmdir(path.wstr().c_str());
+        const int ret = ::rmdir(path_cstr);
         if (ret == -1) {
-                throw std::runtime_error(std::string("Error: ") + strerror(errno)));
+                throw std::runtime_error(std::string("Error: ") + strerror(errno));
         }
 #endif
         return ++count;

--- a/third_party/path.h
+++ b/third_party/path.h
@@ -8,32 +8,33 @@
 */
 #pragma once
 
-#include <cctype>
-#include <cerrno>
-#include <cstdlib>
-#include <cstring>
-#include <fstream>
-#include <sstream>
-#include <stdexcept>
 #include <string>
 #include <vector>
+#include <stdexcept>
+#include <sstream>
+#include <cctype>
+#include <cstdlib>
+#include <cerrno>
+#include <cstring>
+#include <fstream>
 
 #if defined(_WIN32)
-#include <windows.h>
+# include <windows.h>
 #else
-#include <unistd.h>
+# include <unistd.h>
 #endif
 #include <sys/stat.h>
 
 #if defined(__linux)
-#include <linux/limits.h>
+# include <linux/limits.h>
 #endif
 
 // Extra BoB robotics includes
 #include "../common/assert.h"
 #include "tinydir.h"
 
-namespace filesystem {
+namespace filesystem
+{
 
 /**
  * \brief Simple class for manipulating paths on Linux/Windows/Mac OS
@@ -42,11 +43,9 @@ namespace filesystem {
  * dependency until boost::filesystem is integrated into the standard template
  * library at some point in the future.
  */
-class path
-{
+class path {
 public:
-    enum path_type
-    {
+    enum path_type {
         windows_path = 0,
         posix_path = 1,
 #if defined(_WIN32)
@@ -56,61 +55,31 @@ public:
 #endif
     };
 
-    path()
-      : m_type(native_path)
-      , m_absolute(false)
-    {}
+    path() : m_type(native_path), m_absolute(false) { }
 
     path(const path &path)
-      : m_type(path.m_type)
-      , m_path(path.m_path)
-      , m_absolute(path.m_absolute)
-    {}
+        : m_type(path.m_type), m_path(path.m_path), m_absolute(path.m_absolute) {}
 
     path(path &&path)
-      : m_type(path.m_type)
-      , m_path(std::move(path.m_path))
-      , m_absolute(path.m_absolute)
-    {}
+        : m_type(path.m_type), m_path(std::move(path.m_path)),
+          m_absolute(path.m_absolute) {}
 
-    path(const char *string)
-    {
-        set(string);
-    }
+    path(const char *string) { set(string); }
 
-    path(const std::string &string)
-    {
-        set(string);
-    }
+    path(const std::string &string) { set(string); }
 
 #if defined(_WIN32)
-    path(const std::wstring &wstring)
-    {
-        set(wstring);
-    }
-    path(const wchar_t *wstring)
-    {
-        set(wstring);
-    }
+    path(const std::wstring &wstring) { set(wstring); }
+    path(const wchar_t *wstring) { set(wstring); }
 #endif
 
-    size_t length() const
-    {
-        return m_path.size();
-    }
+    size_t length() const { return m_path.size(); }
 
-    bool empty() const
-    {
-        return m_path.empty();
-    }
+    bool empty() const { return m_path.empty(); }
 
-    bool is_absolute() const
-    {
-        return m_absolute;
-    }
+    bool is_absolute() const { return m_absolute; }
 
-    path make_absolute() const
-    {
+    path make_absolute() const {
 #if !defined(_WIN32)
         char temp[PATH_MAX];
         if (realpath(str().c_str(), temp) == NULL)
@@ -125,8 +94,7 @@ public:
 #endif
     }
 
-    bool exists() const
-    {
+    bool exists() const {
 #if defined(_WIN32)
         return GetFileAttributesW(wstr().c_str()) != INVALID_FILE_ATTRIBUTES;
 #else
@@ -135,8 +103,7 @@ public:
 #endif
     }
 
-    size_t file_size() const
-    {
+    size_t file_size() const {
 #if defined(_WIN32)
         struct _stati64 sb;
         if (_wstati64(wstr().c_str(), &sb) != 0)
@@ -149,8 +116,7 @@ public:
         return (size_t) sb.st_size;
     }
 
-    bool is_directory() const
-    {
+    bool is_directory() const {
 #if defined(_WIN32)
         DWORD result = GetFileAttributesW(wstr().c_str());
         if (result == INVALID_FILE_ATTRIBUTES)
@@ -164,8 +130,7 @@ public:
 #endif
     }
 
-    bool is_file() const
-    {
+    bool is_file() const {
 #if defined(_WIN32)
         DWORD attr = GetFileAttributesW(wstr().c_str());
         return (attr != INVALID_FILE_ATTRIBUTES && (attr & FILE_ATTRIBUTE_DIRECTORY) == 0);
@@ -177,25 +142,22 @@ public:
 #endif
     }
 
-    std::string extension() const
-    {
+    std::string extension() const {
         const std::string &name = filename();
         size_t pos = name.find_last_of(".");
         if (pos == std::string::npos)
             return "";
-        return name.substr(pos + 1);
+        return name.substr(pos+1);
     }
 
-    std::string filename() const
-    {
+    std::string filename() const {
         if (empty())
             return "";
-        const std::string &last = m_path[m_path.size() - 1];
+        const std::string &last = m_path[m_path.size()-1];
         return last;
     }
 
-    path parent_path() const
-    {
+    path parent_path() const {
         path result;
         result.m_absolute = m_absolute;
 
@@ -210,8 +172,7 @@ public:
         return result;
     }
 
-    path operator/(const path &other) const
-    {
+    path operator/(const path &other) const {
         if (other.m_absolute)
             throw std::runtime_error("path::operator/(): expected a relative path!");
         if (m_type != other.m_type)
@@ -219,22 +180,21 @@ public:
 
         path result(*this);
 
-        for (size_t i = 0; i < other.m_path.size(); ++i)
+        for (size_t i=0; i<other.m_path.size(); ++i)
             result.m_path.push_back(other.m_path[i]);
 
         return result;
     }
 
-    std::string str(path_type type = native_path) const
-    {
+    std::string str(path_type type = native_path) const {
         std::ostringstream oss;
 
         if (m_type == posix_path && m_absolute)
             oss << "/";
 
-        for (size_t i = 0; i < m_path.size(); ++i) {
+        for (size_t i=0; i<m_path.size(); ++i) {
             oss << m_path[i];
-            if (i + 1 < m_path.size()) {
+            if (i+1 < m_path.size()) {
                 if (type == posix_path)
                     oss << '/';
                 else
@@ -245,8 +205,7 @@ public:
         return oss.str();
     }
 
-    void set(const std::string &str, path_type type = native_path)
-    {
+    void set(const std::string &str, path_type type = native_path) {
         m_type = type;
         if (type == windows_path) {
             m_path = tokenize(str, "/\\");
@@ -257,16 +216,14 @@ public:
         }
     }
 
-    path &operator=(const path &path)
-    {
+    path &operator=(const path &path) {
         m_type = path.m_type;
         m_path = path.m_path;
         m_absolute = path.m_absolute;
         return *this;
     }
 
-    path &operator=(path &&path)
-    {
+    path &operator=(path &&path) {
         if (this != &path) {
             m_type = path.m_type;
             m_path = std::move(path.m_path);
@@ -275,14 +232,12 @@ public:
         return *this;
     }
 
-    friend std::ostream &operator<<(std::ostream &os, const path &path)
-    {
+    friend std::ostream &operator<<(std::ostream &os, const path &path) {
         os << path.str();
         return os;
     }
 
-    bool remove_file() const
-    {
+    bool remove_file() const {
 #if !defined(_WIN32)
         return std::remove(str().c_str()) == 0;
 #else
@@ -290,8 +245,7 @@ public:
 #endif
     }
 
-    bool resize_file(size_t target_length)
-    {
+    bool resize_file(size_t target_length) {
 #if !defined(_WIN32)
         return ::truncate(str().c_str(), (off_t) target_length) == 0;
 #else
@@ -313,8 +267,7 @@ public:
 #endif
     }
 
-    static path getcwd()
-    {
+    static path getcwd() {
 #if !defined(_WIN32)
         char temp[PATH_MAX];
         if (::getcwd(temp, PATH_MAX) == NULL)
@@ -329,45 +282,35 @@ public:
     }
 
 #if defined(_WIN32)
-    std::wstring wstr(path_type type = native_path) const
-    {
+    std::wstring wstr(path_type type = native_path) const {
         std::string temp = str(type);
-        int size = MultiByteToWideChar(CP_UTF8, 0, &temp[0], (int) temp.size(), NULL, 0);
+        int size = MultiByteToWideChar(CP_UTF8, 0, &temp[0], (int)temp.size(), NULL, 0);
         std::wstring result(size, 0);
-        MultiByteToWideChar(CP_UTF8, 0, &temp[0], (int) temp.size(), &result[0], size);
+        MultiByteToWideChar(CP_UTF8, 0, &temp[0], (int)temp.size(), &result[0], size);
         return result;
     }
 
-    void set(const std::wstring &wstring, path_type type = native_path)
-    {
+
+    void set(const std::wstring &wstring, path_type type = native_path) {
         std::string string;
         if (!wstring.empty()) {
-            int size = WideCharToMultiByte(CP_UTF8, 0, &wstring[0], (int) wstring.size(), NULL, 0, NULL, NULL);
+            int size = WideCharToMultiByte(CP_UTF8, 0, &wstring[0], (int)wstring.size(),
+                            NULL, 0, NULL, NULL);
             string.resize(size, 0);
-            WideCharToMultiByte(CP_UTF8, 0, &wstring[0], (int) wstring.size(), &string[0], size, NULL, NULL);
+            WideCharToMultiByte(CP_UTF8, 0, &wstring[0], (int)wstring.size(),
+                                &string[0], size, NULL, NULL);
         }
         set(string, type);
     }
 
-    path &operator=(const std::wstring &str)
-    {
-        set(str);
-        return *this;
-    }
+    path &operator=(const std::wstring &str) { set(str); return *this; }
 #endif
 
-    bool operator==(const path &p) const
-    {
-        return p.m_path == m_path;
-    }
-    bool operator!=(const path &p) const
-    {
-        return p.m_path != m_path;
-    }
+    bool operator==(const path &p) const { return p.m_path == m_path; }
+    bool operator!=(const path &p) const { return p.m_path != m_path; }
 
 protected:
-    static std::vector<std::string> tokenize(const std::string &string, const std::string &delim)
-    {
+    static std::vector<std::string> tokenize(const std::string &string, const std::string &delim) {
         std::string::size_type lastPos = 0, pos = string.find_first_of(delim, lastPos);
         std::vector<std::string> tokens;
 
@@ -389,9 +332,7 @@ protected:
     bool m_absolute;
 };
 
-inline bool
-create_directory(const path &p)
-{
+inline bool create_directory(const path& p) {
 #if defined(_WIN32)
     return CreateDirectoryW(p.wstr().c_str(), NULL) != 0;
 #else
@@ -400,8 +341,7 @@ create_directory(const path &p)
 }
 
 //! BoB's basic implementation for copying a file
-inline void
-copy_file(const filesystem::path &from, const filesystem::path &to)
+inline void copy_file(const filesystem::path &from, const filesystem::path &to)
 {
     std::ifstream ifs(from.str());
     std::ofstream ofs(to.str());
@@ -461,4 +401,4 @@ remove_all(const path &path)
     }
 }
 
-} // namespace filesystem
+}   // namespace filesystem

--- a/third_party/tinydir.h
+++ b/third_party/tinydir.h
@@ -553,6 +553,7 @@ int tinydir_readfile(const tinydir_dir *dir, tinydir_file *file)
 	 * disable it. -- AD
 	 */
 #pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpragmas" // in case compiler doesn't know about -Wrestrict
 #pragma GCC diagnostic ignored "-Wrestrict"
 	_tinydir_strcat(file->path, file->name);
 #pragma GCC diagnostic pop

--- a/third_party/tinydir.h
+++ b/third_party/tinydir.h
@@ -547,7 +547,16 @@ int tinydir_readfile(const tinydir_dir *dir, tinydir_file *file)
 		dir->_e->d_name
 #endif
 	);
+
+	/*
+	 * My version of GCC (8.2.1) gives a warning for this line, so temporarily
+	 * disable it. -- AD
+	 */
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wrestrict"
 	_tinydir_strcat(file->path, file->name);
+#pragma GCC diagnostic pop
+
 #ifndef _MSC_VER
 #ifdef __MINGW32__
 	if (_tstat(

--- a/tools/gantry_db_creator/.gitignore
+++ b/tools/gantry_db_creator/.gitignore
@@ -1,1 +1,1 @@
-gantry/*
+gantry_images/*

--- a/tools/gantry_db_creator/gantry_db_creator.cc
+++ b/tools/gantry_db_creator/gantry_db_creator.cc
@@ -22,24 +22,24 @@ bob_main(int, char **)
     Navigation::Range yrange({ 0_mm, 1700_mm }, 100_mm);
     const auto z = 200_mm;
 
-    // Open gantry and home it
-    Robots::Gantry gantry;
-    std::cout << "Homing gantry." << std::endl;
-    gantry.raiseAndHome();
-    std::cout << "Gantry homed." << std::endl;
-
-    // Get gantry camera
+	// Get gantry camera
     const cv::Size imSize(720, 576);
     Video::OpenCVInput cam(0, "gantry");
     cam.setOutputSize(imSize);
 
     // Save images into a folder called gantry
-    Navigation::ImageDatabase database("gantry");
+    Navigation::ImageDatabase database("gantry_images", /*overwrite=*/true);
     auto gridRecorder = database.getGridRecorder(xrange, yrange, z);
     auto &metadata = gridRecorder.getMetadataWriter();
     metadata << "camera" << cam
              << "needsUnwrapping" << true
              << "isGreyscale" << false;
+
+    // Open gantry and home it
+    Robots::Gantry gantry;
+    std::cout << "Homing gantry." << std::endl;
+    gantry.raiseAndHome();
+    std::cout << "Gantry homed." << std::endl;
 
     cv::Mat frame(imSize, CV_8UC3);
     for (size_t x = 0, y = 0; x < gridRecorder.sizeX();) {

--- a/tools/gantry_db_creator/gantry_db_creator.cc
+++ b/tools/gantry_db_creator/gantry_db_creator.cc
@@ -50,7 +50,7 @@ bob_main(int, char **)
         // While gantry is moving, poll for user keypress
         while (gantry.isMoving()) {
             if ((cv::waitKeyEx(1) & OS::KeyMask) == OS::KeyCodes::Escape) {
-                return 0;
+                return EXIT_SUCCESS;
             }
         }
 
@@ -63,7 +63,7 @@ bob_main(int, char **)
 
         // If we haven't finished moving along y, move along one more
         if ((x % 2) == 0) {
-            if (y < gridRecorder.size()) {
+            if (y < gridRecorder.sizeY() - 1) {
                 y++;
                 continue;
             }


### PR DESCRIPTION
It turns out there was a small bug in the example gantry code we have there which I fixed up.

While I was at it I made some other small fixes and added a ``remove_all()`` function to ``path.h`` (after C++17), which uses the tinydir code. Annoyingly Visual Studio also reformatted all the code in ``path.h``.