### PR TITLE
Use python to ensure we're linking against the version of numpy python is actually using

### DIFF
--- a/make_common/bob_robotics.mk
+++ b/make_common/bob_robotics.mk
@@ -100,7 +100,7 @@ ifdef WITH_MATPLOTLIBCPP
 
 	# extract python version from PYTHON_INCLUDE
 	PYTHON_VERSION       := $(shell echo $(PYTHON_INCLUDE) | cut -f 1 -d " " | grep -e python... -o)
-	PYTHON_NUMPY_INCLUDE ?= $(shell find $$($(PYTHON_CONFIG) --prefix)/lib -type d -path "*/*-packages/numpy/core/include" | grep -m 1 $(PYTHON_VERSION))
+	PYTHON_NUMPY_INCLUDE ?= $(shell $(PYTHON_BIN) $(CURRENT_DIR)/find_numpy.py)
 
 	CXXFLAGS += $(shell $(PYTHON_CONFIG) --includes) -I$(PYTHON_NUMPY_INCLUDE)
 	LINK_FLAGS += $(shell $(PYTHON_CONFIG) --libs)

--- a/make_common/find_numpy.py
+++ b/make_common/find_numpy.py
@@ -1,0 +1,9 @@
+from os import path
+from numpy import __file__ as numpyloc
+
+# Get numpy directory
+numpy_dir = path.dirname(numpyloc)
+
+# Print the result of joining this to core and include
+print(path.join(numpy_dir, "core", "include"))
+


### PR DESCRIPTION
On my laptop, numpy was installed using pip which on Ubuntu 18 means that by default it ends up in ~/.local (which I feel is good). However the mechanism previously used by ``WITH_MATPLOTLIBCPP=1`` fails in this situation (and would also fail if numpy was installed in a virtualenv etc). This change implements the numpy-hunting using Python's own module search which **should** be more robust.