### PR TITLE
Allow for passing pairs of iterators to ``getHeading()`` etc.

### DIFF
--- a/examples/perfect_memory/perfect_memory_test.cc
+++ b/examples/perfect_memory/perfect_memory_test.cc
@@ -1,11 +1,12 @@
-// Standard C++ includes
-#include <iostream>
-
 // BoB robotics includes
 #include "common/timer.h"
 #include "navigation/perfect_memory.h"
 #include "navigation/perfect_memory_store_raw.h"
 #include "navigation/perfect_memory_store_hog.h"
+
+// Standard C++ includes
+#include <algorithm>
+#include <iostream>
 
 using namespace BoBRobotics;
 using namespace BoBRobotics::Navigation;
@@ -41,6 +42,29 @@ main()
         size_t snapshot;
         float difference;
         std::tie(heading, snapshot, difference, allDifferences) = pm.getHeading(snap);
+        std::cout << "Heading: " << heading << std::endl;
+        std::cout << "Best-matching snapshot: #" << snapshot << std::endl;
+        std::cout << "Difference score: " << difference << std::endl;
+    }
+
+    {
+        std::cout << "Testing with best-matching snapshot method with partial rotation..." << std::endl;
+
+        // Default algorithm: find best-matching snapshot, use abs diff
+        PerfectMemoryRotater<> pm(imSize);
+        trainRoute(pm);
+
+        // Time testing phase
+        Timer<> t{ "Time taken for testing: " };
+
+        // Treat snapshot #10 as test data
+        const auto snap = pm.getSnapshot(10);
+        std::vector<size_t> rotations(snap.cols / 2);
+        std::iota(rotations.begin(), rotations.end(), snap.cols / 2);
+
+        size_t snapshot;
+        float difference;
+        std::tie(heading, snapshot, difference, allDifferences) = pm.getHeading(snap, rotations.begin(), rotations.end());
         std::cout << "Heading: " << heading << std::endl;
         std::cout << "Best-matching snapshot: #" << snapshot << std::endl;
         std::cout << "Difference score: " << difference << std::endl;

--- a/hid/joystick_base.h
+++ b/hid/joystick_base.h
@@ -18,15 +18,6 @@ namespace BoBRobotics {
 namespace HID {
 using namespace std::literals;
 
-// helper macros
-#define toIndex(value) static_cast<size_t>(value)
-#define toAxis(value) static_cast<JAxis>(value)
-#define toButton(value) static_cast<JButton>(value)
-
-// maximum values
-#define int16_maxf static_cast<float>(std::numeric_limits<int16_t>::max())
-#define int16_absminf -static_cast<float>(std::numeric_limits<int16_t>::min())
-
 //! The current state of a joystick button
 enum ButtonState
 {
@@ -64,6 +55,19 @@ class JoystickBase : public Threadable
      * @return True if the function has handled the event, false otherwise
      */
     using AxisHandler = std::function<bool(JAxis axis, float value)>;
+
+protected:
+    template<class T>
+    static constexpr size_t toIndex(T value) { return static_cast<size_t>(value); }
+
+    template<class T>
+    static constexpr JAxis toAxis(T value) { return static_cast<JAxis>(value); }
+
+    template<class T>
+    static constexpr JButton toButton(T value) { return static_cast<JButton>(value); }
+
+    static constexpr float int16_maxf() { return static_cast<float>(std::numeric_limits<int16_t>::max()); }
+    static constexpr float int16_absminf() { return -static_cast<float>(std::numeric_limits<int16_t>::min()); }
 
 public:
     //------------------------------------------------------------------------

--- a/hid/joystick_linux.h
+++ b/hid/joystick_linux.h
@@ -180,11 +180,11 @@ private:
         case JAxis::LeftStickVertical:
         case JAxis::RightStickHorizontal:
         case JAxis::RightStickVertical:
-            return value > 0 ? static_cast<float>(value) / int16_maxf
-                             : static_cast<float>(value) / int16_absminf;
+            return value > 0 ? static_cast<float>(value) / int16_maxf()
+                             : static_cast<float>(value) / int16_absminf();
         case JAxis::LeftTrigger:
         case JAxis::RightTrigger:
-            return (static_cast<float>(value) + int16_absminf) /
+            return (static_cast<float>(value) + int16_absminf()) /
                     static_cast<float>(std::numeric_limits<uint16_t>::max());
         case JAxis::DpadHorizontal:
         case JAxis::DpadVertical:

--- a/hid/joystick_windows.h
+++ b/hid/joystick_windows.h
@@ -162,12 +162,12 @@ private:
         switch (axis) {
         case JAxis::LeftStickHorizontal:
         case JAxis::RightStickHorizontal:
-            return value < 0 ? static_cast<float>(value) / int16_absminf
-                             : static_cast<float>(value) / int16_maxf;
+            return value < 0 ? static_cast<float>(value) / int16_absminf()
+                             : static_cast<float>(value) / int16_maxf();
         case JAxis::LeftStickVertical:
         case JAxis::RightStickVertical:
-            return value < 0 ? static_cast<float>(-value) / int16_absminf
-                             : static_cast<float>(-value) / int16_maxf;
+            return value < 0 ? static_cast<float>(-value) / int16_absminf()
+                             : static_cast<float>(-value) / int16_maxf();
         case JAxis::LeftTrigger:
         case JAxis::RightTrigger:
             return static_cast<float>(value) / 255.0f;

--- a/navigation/antworld_rotater.h
+++ b/navigation/antworld_rotater.h
@@ -36,6 +36,7 @@ public:
       , m_UnwrapRes(unwrapRes)
     {
         BOB_ASSERT(agent.getOutputSize() == unwrapRes);
+        BOB_ASSERT(units::math::fmod(360_deg, m_YawStep) == 0_deg);
 
         // This rotater doesn't support mask images
         BOB_ASSERT(maskImage.empty());

--- a/navigation/antworld_rotater.h
+++ b/navigation/antworld_rotater.h
@@ -26,9 +26,9 @@ public:
     AntWorldRotater(const cv::Size &unwrapRes,
                     const cv::Mat &maskImage,
                     AntWorld::AntAgent &agent,
-                    const degree_t &yawStep = 1_deg,
-                    const degree_t &pitch = 0_deg,
-                    const degree_t &roll = 0_deg)
+                    const degree_t yawStep = 1_deg,
+                    const degree_t pitch = 0_deg,
+                    const degree_t roll = 0_deg)
       : m_Agent(agent)
       , m_YawStep(yawStep)
       , m_Pitch(pitch)
@@ -72,8 +72,8 @@ public:
 
 private:
     AntWorld::AntAgent &m_Agent;
-    const degree_t &m_YawStep, &m_Pitch, &m_Roll;
-    const cv::Size &m_UnwrapRes;
+    const degree_t m_YawStep, m_Pitch, m_Roll;
+    const cv::Size m_UnwrapRes;
 }; // AntWorldRotater
 } // Navigation
 } // BoBRobotics

--- a/navigation/antworld_rotater.h
+++ b/navigation/antworld_rotater.h
@@ -1,11 +1,11 @@
 #pragma once
 
-// Third-party includes
-#include "../third_party/units.h"
-
 // BoB robotics includes
 #include "../common/assert.h"
 #include "../libantworld/agent.h"
+
+// Third-party includes
+#include "../third_party/units.h"
 
 namespace BoBRobotics {
 namespace Navigation {
@@ -26,13 +26,14 @@ public:
     AntWorldRotater(const cv::Size &unwrapRes,
                     const cv::Mat &maskImage,
                     AntWorld::AntAgent &agent,
-                    const degree_t yawStep = 1_deg,
-                    const degree_t pitch = 0_deg,
-                    const degree_t roll = 0_deg)
+                    const degree_t &yawStep = 1_deg,
+                    const degree_t &pitch = 0_deg,
+                    const degree_t &roll = 0_deg)
       : m_Agent(agent)
       , m_YawStep(yawStep)
       , m_Pitch(pitch)
       , m_Roll(roll)
+      , m_UnwrapRes(unwrapRes)
     {
         BOB_ASSERT(agent.getOutputSize() == unwrapRes);
 
@@ -52,14 +53,27 @@ public:
         }
     }
 
-    size_t max() const
+    size_t numRotations() const
     {
         return 360_deg / m_YawStep;
     }
 
+    units::angle::radian_t columnToHeading(size_t column) const
+    {
+        return units::angle::turn_t{ (double) column / (double) m_UnwrapRes.width };
+    }
+
+    template<typename... Ts>
+    static auto
+    create(Ts &&... args)
+    {
+        return AntWorldRotater(std::forward<Ts>(args)...);
+    }
+
 private:
     AntWorld::AntAgent &m_Agent;
-    const degree_t m_YawStep, m_Pitch, m_Roll;
+    const degree_t &m_YawStep, &m_Pitch, &m_Roll;
+    const cv::Size &m_UnwrapRes;
 }; // AntWorldRotater
 } // Navigation
 } // BoBRobotics

--- a/navigation/infomax.h
+++ b/navigation/infomax.h
@@ -237,10 +237,10 @@ private:
     {
         // Object for rotating over images
         const cv::Size unwrapRes = this->getUnwrapResolution();
-        Rotater rotater(unwrapRes, this->getMaskImage(), std::forward<Ts>(args)...);
+        auto rotater = Rotater::create(unwrapRes, this->getMaskImage(), std::forward<Ts>(args)...);
 
         // Ensure there's enough space in rotated differe
-        m_RotatedDifferences.reserve(rotater.max());
+        m_RotatedDifferences.reserve(rotater.numRotations());
         m_RotatedDifferences.clear();
 
         // Populate rotated differences with results

--- a/navigation/insilico_rotater.h
+++ b/navigation/insilico_rotater.h
@@ -33,9 +33,9 @@ struct InSilicoRotater
         RotaterInternal(const cv::Size &unwrapRes,
                         const cv::Mat &maskImage,
                         const cv::Mat &image,
+                        size_t scanStep,
                         IterType beginRoll,
-                        IterType endRoll,
-                        size_t scanStep)
+                        IterType endRoll)
           : m_ScanStep(scanStep)
           , m_BeginRoll(beginRoll)
           , m_EndRoll(endRoll)
@@ -134,30 +134,30 @@ struct InSilicoRotater
            const cv::Mat &maskImage,
            const cv::Mat &image,
            IterType beginRoll,
-           IterType endRoll,
-           size_t scanStep = 1)
+           IterType endRoll)
     {
-        return RotaterInternal<IterType>(unwrapRes, maskImage, image, beginRoll, endRoll, scanStep);
+        return RotaterInternal<IterType>(unwrapRes, maskImage, image, 1, beginRoll, endRoll);
     }
 
     static auto
     create(const cv::Size &unwrapRes,
            const cv::Mat &maskImage,
            const cv::Mat &image,
+           size_t scanStep,
            size_t beginRoll,
-           size_t endRoll,
-           size_t scanStep = 1)
+           size_t endRoll)
     {
-        return RotaterInternal<size_t>(unwrapRes, maskImage, image, beginRoll, endRoll, scanStep);
+        return RotaterInternal<size_t>(unwrapRes, maskImage, image, scanStep, beginRoll, endRoll);
     }
 
     static auto
     create(const cv::Size &unwrapRes,
            const cv::Mat &maskImage,
            const cv::Mat &image,
+           size_t scanStep = 1,
            size_t beginRoll = 0)
     {
-        return RotaterInternal<size_t>(unwrapRes, maskImage, image, beginRoll, image.cols, 1);
+        return RotaterInternal<size_t>(unwrapRes, maskImage, image, scanStep, beginRoll, image.cols);
     }
 };
 } // Navigation

--- a/navigation/insilico_rotater.h
+++ b/navigation/insilico_rotater.h
@@ -3,11 +3,19 @@
 // BoB robotics includes
 #include "../common/assert.h"
 
+// Third-party includes
+#include "../third_party/units.h"
+
 // OpenCV
 #include <opencv2/opencv.hpp>
 
+// Standard C++ includes
+#include <algorithm>
+
 namespace BoBRobotics {
 namespace Navigation {
+using namespace units::literals;
+
 //------------------------------------------------------------------------
 // BoBRobotics::Navigation::InSilicoRotater
 //------------------------------------------------------------------------
@@ -16,76 +24,140 @@ namespace Navigation {
  *        image by moving columns of pixels from one side of the image to the
  *        other
  */
-class InSilicoRotater
+struct InSilicoRotater
 {
-public:
-    InSilicoRotater(const cv::Size &unwrapRes,
-                    const cv::Mat &maskImage,
-                    const cv::Mat &image,
-                    size_t scanStep = 1,
-                    size_t beginRoll = 0,
-                    size_t endRoll = std::numeric_limits<size_t>::max())
-    :   m_ScanStep(scanStep), m_BeginRoll(beginRoll), 
-        m_EndRoll((endRoll == std::numeric_limits<size_t>::max()) ? static_cast<size_t>(image.cols) : endRoll)
+    template<typename IterType>
+    class RotaterInternal
     {
-        BOB_ASSERT(image.cols == unwrapRes.width);
-        BOB_ASSERT(image.rows == unwrapRes.height);
-        BOB_ASSERT(image.type() == CV_8UC1);
+    public:
+        RotaterInternal(const cv::Size &unwrapRes,
+                        const cv::Mat &maskImage,
+                        const cv::Mat &image,
+                        IterType beginRoll,
+                        IterType endRoll,
+                        size_t scanStep)
+          : m_ScanStep(scanStep)
+          , m_BeginRoll(beginRoll)
+          , m_EndRoll(endRoll)
+          , m_ImageOriginal(image)
+          , m_MaskImageOriginal(maskImage)
+          , m_Image(unwrapRes.height, unwrapRes.width, CV_8UC1)
+          , m_MaskImage(maskImage.rows, maskImage.cols, maskImage.type())
+        {
+            BOB_ASSERT(image.cols == unwrapRes.width);
+            BOB_ASSERT(image.rows == unwrapRes.height);
+            BOB_ASSERT(image.type() == CV_8UC1);
+            BOB_ASSERT(image.isContinuous());
 
-        image.copyTo(m_Image);
-        maskImage.copyTo(m_MaskImage);
-    }
-
-    template<class Func>
-    void rotate(Func func)
-    {
-        // If we are starting scanning from a point other than zero
-        if(m_BeginRoll != 0) {
-            // Roll image and mask (if required)
-            rollImage(m_Image, m_BeginRoll);
-            if (!m_MaskImage.empty()) {
-                rollImage(m_MaskImage, m_BeginRoll);
+            const auto index = toIndex(beginRoll);
+            rollImage(image, m_Image, index);
+            if (!maskImage.empty()) {
+                rollImage(maskImage, m_MaskImage, index);
             }
         }
-        
-        size_t i = m_BeginRoll;
-        while (true) {
-            func(m_Image, m_MaskImage, i - m_BeginRoll);
 
-            i += m_ScanStep;
-            if (i >= m_EndRoll) {
-                break;
-            }
+        template<class Func>
+        void rotate(Func func)
+        {
+            auto i = m_BeginRoll;
+            while (true) {
+                func(m_Image, m_MaskImage, distance(m_BeginRoll, i));
 
-            rollImage(m_Image, m_ScanStep);
-            if (!m_MaskImage.empty()) {
-                rollImage(m_MaskImage, m_ScanStep);
+                i += m_ScanStep;
+                if (i >= m_EndRoll) {
+                    break;
+                }
+
+                const auto index = toIndex(i);
+                rollImage(m_ImageOriginal, m_Image, index);
+                if (!m_MaskImageOriginal.empty()) {
+                    rollImage(m_MaskImageOriginal, m_MaskImage, index);
+                }
             }
         }
-    }
 
-    size_t max() const
-    {
-        return (m_EndRoll - m_BeginRoll) / m_ScanStep;
-    }
-
-private:
-    const size_t m_ScanStep;
-    const size_t m_BeginRoll;
-    const size_t m_EndRoll;
-    cv::Mat m_Image, m_MaskImage;
-
-    static void rollImage(cv::Mat &image, size_t pixels)
-    {
-        BOB_ASSERT(image.isContinuous());
-        // Loop through rows
-        for (int y = 0; y < image.rows; y++) {
-            // Get pointer to start of row
-            uint8_t *rowPtr = image.ptr(y);
-
-            // Rotate row to left by pixels
-            std::rotate(rowPtr, rowPtr + pixels, rowPtr + image.cols);
+        units::angle::radian_t columnToHeading(size_t column) const
+        {
+            return units::angle::turn_t{ (double) toIndex(column) / (double) m_ImageOriginal.cols };
         }
+
+        size_t numRotations() const
+        {
+            return (m_EndRoll - m_BeginRoll) / m_ScanStep;
+        }
+
+    private:
+        const size_t m_ScanStep;
+        const IterType m_BeginRoll, m_EndRoll;
+        const cv::Mat &m_ImageOriginal, &m_MaskImageOriginal;
+        cv::Mat m_Image, m_MaskImage;
+
+        static void rollImage(const cv::Mat &imageIn, cv::Mat &imageOut, size_t pixels)
+        {
+            // Loop through rows
+            for (int y = 0; y < imageIn.rows; y++) {
+                // Get pointer to start of row
+                const uint8_t *rowPtr = imageIn.ptr(y);
+                uint8_t *rowPtrOut = imageOut.ptr(y);
+
+                // Rotate row to left by pixels
+                std::rotate_copy(rowPtr, rowPtr + pixels, rowPtr + imageIn.cols, rowPtrOut);
+            }
+        }
+
+        static size_t distance(size_t first, size_t last)
+        {
+            return last - first;
+        }
+
+        template<typename Iter>
+        static size_t distance(Iter first, Iter last)
+        {
+            return static_cast<size_t>(std::distance(first, last));
+        }
+
+        static size_t toIndex(size_t index)
+        {
+            return index;
+        }
+
+        template<typename Iter>
+        static size_t toIndex(Iter it)
+        {
+            return *it;
+        }
+    };
+
+    template<typename IterType>
+    static auto
+    create(const cv::Size &unwrapRes,
+           const cv::Mat &maskImage,
+           const cv::Mat &image,
+           IterType beginRoll,
+           IterType endRoll,
+           size_t scanStep = 1)
+    {
+        return RotaterInternal<IterType>(unwrapRes, maskImage, image, beginRoll, endRoll, scanStep);
+    }
+
+    static auto
+    create(const cv::Size &unwrapRes,
+           const cv::Mat &maskImage,
+           const cv::Mat &image,
+           size_t beginRoll,
+           size_t endRoll,
+           size_t scanStep = 1)
+    {
+        return RotaterInternal<size_t>(unwrapRes, maskImage, image, beginRoll, endRoll, scanStep);
+    }
+
+    static auto
+    create(const cv::Size &unwrapRes,
+           const cv::Mat &maskImage,
+           const cv::Mat &image,
+           size_t beginRoll = 0)
+    {
+        return RotaterInternal<size_t>(unwrapRes, maskImage, image, beginRoll, image.cols, 1);
     }
 };
 } // Navigation

--- a/navigation/insilico_rotater.h
+++ b/navigation/insilico_rotater.h
@@ -48,6 +48,8 @@ struct InSilicoRotater
             BOB_ASSERT(image.rows == unwrapRes.height);
             BOB_ASSERT(image.type() == CV_8UC1);
             BOB_ASSERT(image.isContinuous());
+            BOB_ASSERT(beginRoll < endRoll);
+            BOB_ASSERT((distance(endRoll, beginRoll) % scanStep) == 0);
 
             const auto index = toIndex(beginRoll);
             rollImage(image, m_Image, index);


### PR DESCRIPTION
I had to rework various bits of the internal API to make this work, but now you should be able to do:
```
const auto heading = pm.getHeading(image, rotations.begin(), rotations.end());
```
and
```
const auto heading = pm.getHeading(image, 90, 180, 2);
```
etc.

I've done the PR into your branch to make it easier to look at the diff.