### PR TITLE
Using LM9DS1 to stabilise unwrapping

### DIFF
--- a/examples/camera_360_stable/Makefile
+++ b/examples/camera_360_stable/Makefile
@@ -1,0 +1,2 @@
+WITH_I2C := 1
+include ../../make_common/default.mk

--- a/examples/camera_360_stable/camera_360_stable.cc
+++ b/examples/camera_360_stable/camera_360_stable.cc
@@ -1,0 +1,111 @@
+// BoB robotics includes
+#include "common/logging.h"
+#include "common/lm9ds1_imu.h"
+#include "common/timer.h"
+#include "imgproc/opencv_unwrap_360.h"
+#include "video/panoramic.h"
+
+// Standard C++ includes
+#include <iostream>
+
+// Standard C includes
+#include <cmath>
+
+using namespace BoBRobotics;
+using namespace BoBRobotics::ImgProc;
+using namespace BoBRobotics::Video;
+
+int main()
+{
+    const cv::Size unwrapRes(720, 150);
+
+    // Create panoramic camera and suitable unwrapper
+    auto cam = getPanoramicCamera();
+    auto unwrapper = cam->createUnwrapper(unwrapRes);
+    const auto cameraRes = cam->getOutputSize();
+
+    // The cirlce we're unwrapping within represents a 
+    // half sphere, therefore it's radius is the arc length
+    const double quarterArcLength = unwrapper.m_OuterPixel - unwrapper.m_InnerPixel;
+    
+    // Cache original centre pixel
+    const auto originalCentrePixel = unwrapper.m_CentrePixel;
+    
+    // Configure IMU accelerometer
+    LM9DS1 imu;
+    LM9DS1::AccelSettings accelSettings;
+    imu.initAccel(accelSettings);
+
+    // Create images
+    cv::Mat originalImage(cameraRes, CV_8UC3);
+    cv::Mat outputImage(unwrapRes, CV_8UC3);
+
+    // Create motor
+    cv::namedWindow("Unwrapped", cv::WINDOW_NORMAL);
+    cv::resizeWindow("Unwrapped", unwrapRes.width, unwrapRes.height);
+
+    cv::namedWindow("Original", cv::WINDOW_NORMAL);
+    cv::resizeWindow("Original", cameraRes.width / 2, cameraRes.height / 2);
+
+    {
+        Timer<> timer("Total time:");
+
+        unsigned int frame = 0;
+        for(frame = 0;; frame++) {
+            // Read from camera
+            if(!cam->readFrame(originalImage)) {
+                return EXIT_FAILURE;
+            }
+            
+            // If there is new accelerometer data available
+            if(imu.isAccelAvailable()) {
+                // Read sample
+                float accelData[3];
+                imu.readAccel(accelData);
+                
+                // Calculate roll and pitch angles (in radians)
+                const double roll = atan2(accelData[0], sqrt((accelData[2] * accelData[2]) + (accelData[1] * accelData[1])));
+                const double pitch = atan2(accelData[2], sqrt((accelData[1] * accelData[1]) + (accelData[1] * accelData[1])));
+        
+                // Convert roll and pitch angles to pixels along surface of half sphere and calculate new centre
+                unwrapper.m_CentrePixel.x = originalCentrePixel.x - (int)std::round(roll * quarterArcLength);
+                unwrapper.m_CentrePixel.y = originalCentrePixel.y - (int)std::round(pitch * quarterArcLength);
+                
+                // Update unwrapping maps
+                unwrapper.updateMaps();
+            }
+
+            // Unwrap
+            unwrapper.unwrap(originalImage, outputImage);
+            
+            // Draw cross as stabilised centre
+            cv::line(originalImage, 
+                     cv::Point(unwrapper.m_CentrePixel.x - 20,
+                               unwrapper.m_CentrePixel.y),
+                     cv::Point(unwrapper.m_CentrePixel.x + 20,
+                               unwrapper.m_CentrePixel.y), 
+                     cv::Scalar(0x00, 0xff, 0x00), 2);
+            cv::line(originalImage, 
+                     cv::Point(unwrapper.m_CentrePixel.x,
+                               unwrapper.m_CentrePixel.y - 20),
+                     cv::Point(unwrapper.m_CentrePixel.x,
+                               unwrapper.m_CentrePixel.y + 20), 
+                     cv::Scalar(0x00, 0xff, 0x00), 2);
+
+            // Show frame difference
+            cv::imshow("Original", originalImage);
+            cv::imshow("Unwrapped", outputImage);
+
+            if(cv::waitKey(1) == 27) {
+                break;
+            }
+        }
+
+        const double msPerFrame = timer.get() / (double)frame;
+        std::cout << "FPS:" << 1000.0 / msPerFrame << std::endl;
+    }
+
+    return EXIT_SUCCESS;
+}
+
+

--- a/examples/camera_360_stable/camera_360_stable.cc
+++ b/examples/camera_360_stable/camera_360_stable.cc
@@ -26,7 +26,7 @@ int main()
 
     // The cirlce we're unwrapping within represents a 
     // half sphere, therefore it's radius is the arc length
-    const double quarterArcLength = unwrapper.m_OuterPixel - unwrapper.m_InnerPixel;
+    const float quarterArcLength = (float)unwrapper.m_OuterPixel - (float)unwrapper.m_InnerPixel;
     
     // Cache original centre pixel
     const auto originalCentrePixel = unwrapper.m_CentrePixel;
@@ -64,8 +64,8 @@ int main()
                 imu.readAccel(accelData);
                 
                 // Calculate roll and pitch angles (in radians)
-                const double roll = atan2(accelData[0], sqrt((accelData[2] * accelData[2]) + (accelData[1] * accelData[1])));
-                const double pitch = atan2(accelData[2], sqrt((accelData[1] * accelData[1]) + (accelData[1] * accelData[1])));
+                const float roll = atan2(accelData[0], sqrt((accelData[2] * accelData[2]) + (accelData[1] * accelData[1])));
+                const float pitch = atan2(accelData[2], sqrt((accelData[1] * accelData[1]) + (accelData[1] * accelData[1])));
         
                 // Convert roll and pitch angles to pixels along surface of half sphere and calculate new centre
                 unwrapper.m_CentrePixel.x = originalCentrePixel.x - (int)std::round(roll * quarterArcLength);


### PR DESCRIPTION
I was thinking that if we're going to use the robots on a slope, some sort of stabilisation is going to really help improve the in-silica rotation. This is my, somewhat hacky, attempt at doing it using existing code. However, **ideally** we would do the equivalent of:

1. Call ``unwrapMaps`` once with ``m_CentrePixel`` = (0, 0)
2. Copy ``m_UnwrapMapX`` and ``m_UnwrapMapY`` somewhere.
3. When we change ``m_CentrePixel``, ``cv::add`` the offset to our copy of ``m_UnwrapMapX`` and ``m_UnwrapMapY``

Rather than calling ``unwrapMaps`` every time we update the centre pixel. Do you have any thoughts on how this could be integrated with the OpenCV unwrapper?  I think the ideal API would be:
```c++
void unwrap(const cv::Mat &input, cv::Mat &output, degree_t roll, degree_t pitch)
```