### PR TITLE
Add 360 degree camera to gazebo_tank

### DIFF
--- a/examples/gazebo_tank/differential_drive_panoramic.world
+++ b/examples/gazebo_tank/differential_drive_panoramic.world
@@ -17,7 +17,7 @@
       </include>
       
       <include >
-        <uri>simple_camera</uri>
+        <uri>panoramic_camera</uri>
       </include>
       <!-- Attach the plugin to this model -->
       <plugin name="differential_drive_control" filename="libdifferential_drive_plugin.so">

--- a/examples/gazebo_tank/differential_drive_robot/model.sdf
+++ b/examples/gazebo_tank/differential_drive_robot/model.sdf
@@ -397,121 +397,7 @@
         </surface>
       </collision>
     </link>
-    <model name='camera'>
-      <pose frame=''>-1.07303 0 0.28895 0 0 3.14159</pose>
-      <link name='link'>
-        <inertial>
-          <mass>0.1</mass>
-          <inertia>
-            <ixx>0.000166667</ixx>
-            <iyy>0.000166667</iyy>
-            <izz>0.000166667</izz>
-            <ixy>0</ixy>
-            <ixz>0</ixz>
-            <iyz>0</iyz>
-          </inertia>
-          <pose frame=''>0 0 0 0 -0 0</pose>
-        </inertial>
-        <collision name='collision'>
-          <geometry>
-            <box>
-              <size>0.1 0.1 0.1</size>
-            </box>
-          </geometry>
-          <max_contacts>10</max_contacts>
-          <surface>
-            <contact>
-              <ode/>
-            </contact>
-            <bounce/>
-            <friction>
-              <torsional>
-                <ode/>
-              </torsional>
-              <ode/>
-            </friction>
-          </surface>
-        </collision>
-        <visual name='visual'>
-          <geometry>
-            <box>
-              <size>0.1 0.1 0.1</size>
-            </box>
-          </geometry>
-        </visual>
-        <sensor name='camera' type='camera'>
-          <camera name='__default__'>
-            <horizontal_fov>1.047</horizontal_fov>
-            <image>
-              <width>640</width>
-              <height>480</height>
-            </image>
-            <clip>
-              <near>0.1</near>
-              <far>100</far>
-            </clip>
-          </camera>
-          <always_on>1</always_on>
-          <update_rate>30</update_rate>
-          <visualize>1</visualize>
-        </sensor>
-        <self_collide>0</self_collide>
-        <enable_wind>0</enable_wind>
-        <kinematic>0</kinematic>
-      </link>
-    </model>
-     
-     <!--
-     <model name="wideanglecamera">
-    <pose>0 0 0.05 0 0 0</pose>
-    <link name="link">
-      <inertial>
-        <mass>0.1</mass>
-      </inertial>
-      <collision name="collision">
-        <geometry>
-          <box>
-            <size>0.1 0.1 0.1</size>
-          </box>
-        </geometry>
-      </collision>
-      <visual name="visual">
-        <geometry>
-          <box>
-            <size>0.1 0.1 0.1</size>
-          </box>
-        </geometry>
-      </visual>
-      <sensor name="camera" type="wideanglecamera">
-        <camera>
-          <horizontal_fov>6.2831</horizontal_fov>
-          <image>
-            <width>320</width>
-            <height>240</height>
-          </image>
-          <clip>
-            <near>0.1</near>
-            <far>100</far>
-          </clip>
-          <lens>
-            <type>custom</type>
-            <scale_to_hfov>true</scale_to_hfov>
-            <cutoff_angle>3.1415</cutoff_angle>
-            <env_texture_size>512</env_texture_size>
-            <custom_function>
-            <c1>1.05</c1>
-            <c2>4</c2>
-            <f>1.0</f>
-            <fun>tan</fun>
-          </custom_function>
-          </lens>
-        </camera>
-        <always_on>1</always_on>
-        <update_rate>30</update_rate>
-      </sensor>
-    </link>
-  </model>
-  -->
+    
     <joint name='link_0_JOINT_0' type='revolute'>
       <parent>link_0</parent>
       <child>link_1</child>
@@ -581,23 +467,6 @@
     <joint name='link_0_JOINT_2' type='ball'>
       <parent>link_0</parent>
       <child>link_2</child>
-      <pose frame=''>0 0 0 0 -0 0</pose>
-      <physics>
-        <ode>
-          <limit>
-            <cfm>0</cfm>
-            <erp>0.2</erp>
-          </limit>
-          <suspension>
-            <cfm>0</cfm>
-            <erp>0.2</erp>
-          </suspension>
-        </ode>
-      </physics>
-    </joint>
-    <joint name='link_0_JOINT_0_0' type='fixed'>
-      <parent>link_0</parent>
-      <child>camera::link</child>
       <pose frame=''>0 0 0 0 -0 0</pose>
       <physics>
         <ode>

--- a/examples/gazebo_tank/differential_drive_robot/model.sdf
+++ b/examples/gazebo_tank/differential_drive_robot/model.sdf
@@ -27,18 +27,10 @@
           </box>
         </geometry>
         <material>
-          <lighting>1</lighting>
-          <script>
-            <uri>file://media/materials/scripts/gazebo.material</uri>
-            <name>Gazebo/Grey</name>
-          </script>
-          <shader type='pixel'>
-            <normal_map>__default__</normal_map>
-          </shader>
-          <ambient>0.3 0.3 0.3 1</ambient>
-          <diffuse>0.7 0.7 0.7 1</diffuse>
-          <specular>0.01 0.01 0.01 1</specular>
-          <emissive>0 0 0 1</emissive>
+          <ambient>1 0 0 1</ambient>
+          <diffuse>1 0 0 1</diffuse>
+          <specular>0.1 0.1 0.1 1</specular>
+          <emissive>0 0 0 0</emissive>
         </material>
         <transparency>0</transparency>
         <cast_shadows>1</cast_shadows>
@@ -126,18 +118,10 @@
           </cylinder>
         </geometry>
         <material>
-          <lighting>1</lighting>
-          <script>
-            <uri>file://media/materials/scripts/gazebo.material</uri>
-            <name>Gazebo/Grey</name>
-          </script>
-          <shader type='pixel'>
-            <normal_map>__default__</normal_map>
-          </shader>
-          <ambient>0.3 0.3 0.3 1</ambient>
-          <diffuse>0.7 0.7 0.7 1</diffuse>
-          <specular>0.01 0.01 0.01 1</specular>
-          <emissive>0 0 0 1</emissive>
+          <ambient>0 1 0.5 1</ambient>
+          <diffuse>0 1 0.5 1</diffuse>
+          <specular>0.1 0.1 0.1 1</specular>
+          <emissive>0 0 0 0</emissive>
         </material>
         <transparency>0</transparency>
         <cast_shadows>1</cast_shadows>
@@ -226,18 +210,10 @@
           </cylinder>
         </geometry>
         <material>
-          <lighting>1</lighting>
-          <script>
-            <uri>file://media/materials/scripts/gazebo.material</uri>
-            <name>Gazebo/Grey</name>
-          </script>
-          <shader type='pixel'>
-            <normal_map>__default__</normal_map>
-          </shader>
-          <ambient>0.3 0.3 0.3 1</ambient>
-          <diffuse>0.7 0.7 0.7 1</diffuse>
-          <specular>0.01 0.01 0.01 1</specular>
-          <emissive>0 0 0 1</emissive>
+          <ambient>0 1 1 1</ambient>
+          <diffuse>0 1 1 1</diffuse>
+          <specular>0.1 0.1 0.1 1</specular>
+          <emissive>0 0 0 0</emissive>
         </material>
         <transparency>0</transparency>
         <cast_shadows>1</cast_shadows>
@@ -325,18 +301,10 @@
           </sphere>
         </geometry>
         <material>
-          <lighting>1</lighting>
-          <script>
-            <uri>file://media/materials/scripts/gazebo.material</uri>
-            <name>Gazebo/Grey</name>
-          </script>
-          <shader type='pixel'>
-            <normal_map>__default__</normal_map>
-          </shader>
-          <ambient>0.3 0.3 0.3 1</ambient>
-          <diffuse>0.7 0.7 0.7 1</diffuse>
-          <specular>0.01 0.01 0.01 1</specular>
-          <emissive>0 0 0 1</emissive>
+          <ambient>1 0 1 1</ambient>
+          <diffuse>1 0 1 1</diffuse>
+          <specular>0.1 0.1 0.1 1</specular>
+          <emissive>0 0 0 0</emissive>
         </material>
         <transparency>0</transparency>
         <cast_shadows>1</cast_shadows>

--- a/examples/gazebo_tank/gazebo_panoramic_camera.yaml
+++ b/examples/gazebo_tank/gazebo_panoramic_camera.yaml
@@ -1,0 +1,8 @@
+%YAML:1.0
+---
+unwrapper:
+    centre: [0.5, 0.5]
+    inner: 0
+    outer: 0.5
+    offsetDegrees: 0
+    flip: 0

--- a/examples/gazebo_tank/gazebo_tank.cc
+++ b/examples/gazebo_tank/gazebo_tank.cc
@@ -31,10 +31,14 @@ bob_main(int argc, char **argv)
     gazebo::transport::NodePtr node = getGazeboNode();
 
     /************************************Gazebo setup end************/
-    //Initialize Gazebo camera display if -d arguement supplied
-    GazeboCameraInput cam(node, "/gazebo/default/differential_drive_robot/camera/link/camera/image");
+    char* camera_url="";
+    if(argc >= 3) {
+        camera_url = argv[2];
+    }    
+    GazeboCameraInput cam(node, camera_url);
     Display display(cam);
-    if(argc >= 2 && strcmp(argv[1], "-d") == 0) {
+    //Initialize Gazebo camera display if -d arguement supplied
+    if(argc >= 3 && strcmp(argv[1], "-d") == 0) {
         std::cout << "Display switch enabled.\n";
         display.runInBackground();
     }

--- a/examples/gazebo_tank/gazebo_tank.cc
+++ b/examples/gazebo_tank/gazebo_tank.cc
@@ -31,23 +31,21 @@ bob_main(int argc, char **argv)
     gazebo::transport::NodePtr node = getGazeboNode();
 
     /************************************Gazebo setup end************/
-    Display* display;
-    GazeboCameraInput* cam;
-    if(argc >= 3) {
+    std::unique_ptr<GazeboCameraInput> cam;
+    std::unique_ptr<Display> display;
+    if(argc >= 3) { // Initialize gazebo camera if more than 2 arguements are provided (display switch and camera url)
         std::cout << "Display switch enabled.\n";
-        if(strcmp(argv[1], "-p") == 0) {
+        if(strcmp(argv[1], "-p") == 0) { 
             std::cout << "Using panoramic camera.\n";
-            cam = new GazeboCameraInput(node, argv[2], "gazebo_panoramic_camera");
-            display = new Display(*cam, cv::Size(640,320)); //unwrap resolution needs to be supplied
-            display->runInBackground();
+            cam = std::make_unique<GazeboCameraInput>(node, argv[2], "gazebo_panoramic_camera");
+            display = std::make_unique<Display>(*cam, cv::Size(640,320)); //unwrap resolution needs to be supplied
         }
         else if(strcmp(argv[1], "-s") == 0){
             std::cout << "Using simple camera.\n";
-            cam = new GazeboCameraInput(node, argv[2]);
-            display = new Display(*cam); //unwrap resolution needs to be supplied
-            display->runInBackground();
+            cam = std::make_unique<GazeboCameraInput>(node, argv[2]);
+            display = std::make_unique<Display>(*cam); //unwrap resolution needs to be supplied
         }
-        //Initialize Gazebo camera display if -d arguement supplied
+        display->runInBackground();
     }
 
     Robots::GazeboTank robot(5_rad_per_s, node); // Tank agent
@@ -64,8 +62,6 @@ bob_main(int argc, char **argv)
         }
     } while (!joystick.isPressed(HID::JButton::B));
     // Make sure to shut everything down.
-    delete display;
-    delete cam;
     shutdownGazeboNode();
     std::cout <<"Shutting down...\n";
 

--- a/examples/gazebo_tank/gazebo_tank.cc
+++ b/examples/gazebo_tank/gazebo_tank.cc
@@ -31,8 +31,8 @@ bob_main(int argc, char **argv)
     gazebo::transport::NodePtr node = getGazeboNode();
 
     /************************************Gazebo setup end************/
-    std::unique_ptr<GazeboCameraInput> cam;
     std::unique_ptr<Display> display;
+    std::unique_ptr<GazeboCameraInput> cam;
     if(argc >= 3) { // Initialize gazebo camera if more than 2 arguements are provided (display switch and camera url)
         std::cout << "Display switch enabled.\n";
         if(strcmp(argv[1], "-p") == 0) { 

--- a/examples/gazebo_tank/gazebo_tank.cc
+++ b/examples/gazebo_tank/gazebo_tank.cc
@@ -37,12 +37,12 @@ bob_main(int argc, char **argv)
         std::cout << "Display switch enabled.\n";
         if(strcmp(argv[1], "-p") == 0) { 
             std::cout << "Using panoramic camera.\n";
-            cam = std::make_unique<GazeboCameraInput>(node, argv[2], "gazebo_panoramic_camera");
+            cam = std::make_unique<GazeboCameraInput>(node, argv[2], true);
             display = std::make_unique<Display>(*cam, cv::Size(640,320)); //unwrap resolution needs to be supplied
         }
         else if(strcmp(argv[1], "-s") == 0){
             std::cout << "Using simple camera.\n";
-            cam = std::make_unique<GazeboCameraInput>(node, argv[2]);
+            cam = std::make_unique<GazeboCameraInput>(node, argv[2], false);
             display = std::make_unique<Display>(*cam); //unwrap resolution needs to be supplied
         }
         display->runInBackground();
@@ -62,6 +62,7 @@ bob_main(int argc, char **argv)
         }
     } while (!joystick.isPressed(HID::JButton::B));
     // Make sure to shut everything down.
+    display->close();
     shutdownGazeboNode();
     std::cout <<"Shutting down...\n";
 

--- a/examples/gazebo_tank/gazebo_tank.cc
+++ b/examples/gazebo_tank/gazebo_tank.cc
@@ -31,16 +31,23 @@ bob_main(int argc, char **argv)
     gazebo::transport::NodePtr node = getGazeboNode();
 
     /************************************Gazebo setup end************/
-    char* camera_url="";
+    Display* display;
+    GazeboCameraInput* cam;
     if(argc >= 3) {
-        camera_url = argv[2];
-    }    
-    GazeboCameraInput cam(node, camera_url);
-    Display display(cam);
-    //Initialize Gazebo camera display if -d arguement supplied
-    if(argc >= 3 && strcmp(argv[1], "-d") == 0) {
         std::cout << "Display switch enabled.\n";
-        display.runInBackground();
+        if(strcmp(argv[1], "-p") == 0) {
+            std::cout << "Using panoramic camera.\n";
+            cam = new GazeboCameraInput(node, argv[2], "gazebo_panoramic_camera");
+            display = new Display(*cam, cv::Size(640,320)); //unwrap resolution needs to be supplied
+            display->runInBackground();
+        }
+        else if(strcmp(argv[1], "-s") == 0){
+            std::cout << "Using simple camera.\n";
+            cam = new GazeboCameraInput(node, argv[2]);
+            display = new Display(*cam); //unwrap resolution needs to be supplied
+            display->runInBackground();
+        }
+        //Initialize Gazebo camera display if -d arguement supplied
     }
 
     Robots::GazeboTank robot(5_rad_per_s, node); // Tank agent
@@ -57,6 +64,8 @@ bob_main(int argc, char **argv)
         }
     } while (!joystick.isPressed(HID::JButton::B));
     // Make sure to shut everything down.
+    delete display;
+    delete cam;
     shutdownGazeboNode();
     std::cout <<"Shutting down...\n";
 

--- a/examples/gazebo_tank/panoramic_camera/model.config
+++ b/examples/gazebo_tank/panoramic_camera/model.config
@@ -1,0 +1,11 @@
+<?xml version="1.0" ?>
+<model>
+    <name>panoramic_camera</name>
+    <version>1.0</version>
+    <sdf version="1.6">model.sdf</sdf>
+    <author>
+        <name>Shinjan Mitra</name>
+        <email>shinjanxp@gmail.com</email>
+    </author>
+    <description>360 degree panoramic camera</description>
+</model>

--- a/examples/gazebo_tank/panoramic_camera/model.sdf
+++ b/examples/gazebo_tank/panoramic_camera/model.sdf
@@ -1,10 +1,19 @@
 <?xml version='1.0'?>
 <sdf version='1.6'>
   <model name="panoramic_camera">
-     <pose frame=''>-1.07303 0 0.28895 0 0 3.14159</pose>
+     <pose frame=''>-1.07303 0 0.4 0 -1.5707 0</pose>
     <link name="link">
       <inertial>
         <mass>0.1</mass>
+        <pose frame=''>0 0 0 0 -0 0</pose>
+        <inertia>
+          <ixx>0.0001</ixx>
+          <ixy>0</ixy>
+          <ixz>0</ixz>
+          <iyy>0.0001</iyy>
+          <iyz>0</iyz>
+          <izz>0.0001</izz>
+        </inertia>
       </inertial>
       <collision name="collision">
         <geometry>
@@ -25,7 +34,8 @@
           <horizontal_fov>6.2831</horizontal_fov>
           <image>
             <width>640</width>
-            <height>480</height>
+            <height>640</height>
+            <format>B8G8R8</format>
           </image>
           <clip>
             <near>0.1</near>
@@ -33,13 +43,13 @@
           </clip>
           <lens>
             <type>custom</type>
-            <scale_to_hfov>true</scale_to_hfov>
-            <cutoff_angle>3.1415</cutoff_angle>
+            <scale_to_hfov>false</scale_to_hfov>
+            <cutoff_angle>6.2831</cutoff_angle>
             <env_texture_size>512</env_texture_size>
             <custom_function>
             <c1>1.05</c1>
             <c2>4</c2>
-            <f>1.0</f>
+            <f>2</f>
             <fun>tan</fun>
           </custom_function>
           </lens>

--- a/examples/gazebo_tank/panoramic_camera/model.sdf
+++ b/examples/gazebo_tank/panoramic_camera/model.sdf
@@ -1,0 +1,70 @@
+<?xml version='1.0'?>
+<sdf version='1.6'>
+  <model name="panoramic_camera">
+     <pose frame=''>-1.07303 0 0.28895 0 0 3.14159</pose>
+    <link name="link">
+      <inertial>
+        <mass>0.1</mass>
+      </inertial>
+      <collision name="collision">
+        <geometry>
+          <box>
+            <size>0.1 0.1 0.1</size>
+          </box>
+        </geometry>
+      </collision>
+      <visual name="visual">
+        <geometry>
+          <box>
+            <size>0.1 0.1 0.1</size>
+          </box>
+        </geometry>
+      </visual>
+      <sensor name="camera" type="wideanglecamera">
+        <camera>
+          <horizontal_fov>6.2831</horizontal_fov>
+          <image>
+            <width>640</width>
+            <height>480</height>
+          </image>
+          <clip>
+            <near>0.1</near>
+            <far>100</far>
+          </clip>
+          <lens>
+            <type>custom</type>
+            <scale_to_hfov>true</scale_to_hfov>
+            <cutoff_angle>3.1415</cutoff_angle>
+            <env_texture_size>512</env_texture_size>
+            <custom_function>
+            <c1>1.05</c1>
+            <c2>4</c2>
+            <f>1.0</f>
+            <fun>tan</fun>
+          </custom_function>
+          </lens>
+        </camera>
+        <always_on>1</always_on>
+        <update_rate>30</update_rate>
+      </sensor>
+    </link>
+    <joint name='link_0_JOINT_0_0' type='fixed'>
+      <parent>differential_drive_robot::link_0</parent>
+      <child>panoramic_camera::link</child>
+      <pose frame=''>0 0 0 0 -0 0</pose>
+      <physics>
+        <ode>
+          <limit>
+            <cfm>0</cfm>
+            <erp>0.2</erp>
+          </limit>
+          <suspension>
+            <cfm>0</cfm>
+            <erp>0.2</erp>
+          </suspension>
+        </ode>
+      </physics>
+    </joint>
+  </model>
+
+</sdf>

--- a/examples/gazebo_tank/run.sh
+++ b/examples/gazebo_tank/run.sh
@@ -10,9 +10,10 @@ print_usage() {
 
 while getopts 'dp' flag; do
   case "${flag}" in
-    d) display_flag='-d' ;;
-    p) world_file=differential_drive_panoramic.world 
-        camera_url='/gazebo/default/differential_drive_robot/panoramic_camera/link/camera/image';;
+    d) display_flag='-s' ;;
+    p)  world_file=differential_drive_panoramic.world 
+        camera_url='/gazebo/default/differential_drive_robot/panoramic_camera/link/camera/image'
+        display_flag='-p' ;;
     *) print_usage
        exit 1 ;;
   esac

--- a/examples/gazebo_tank/run.sh
+++ b/examples/gazebo_tank/run.sh
@@ -1,3 +1,21 @@
 #!/bin/sh
 trap 'kill %1' SIGINT
-GAZEBO_PLUGIN_PATH=$GAZEBO_PLUGIN_PATH:$(dirname "$0") gazebo --verbose differential_drive.world & ./gazebo_tank "$@"
+world_file=differential_drive.world
+display_flag=''
+camera_url='/gazebo/default/differential_drive_robot/simple_camera/link/camera/image'
+
+print_usage() {
+  printf "Usage: ./run.sh <-d> <-p>\n"
+}
+
+while getopts 'dp' flag; do
+  case "${flag}" in
+    d) display_flag='-d' ;;
+    p) world_file=differential_drive_panoramic.world 
+        camera_url='/gazebo/default/differential_drive_robot/panoramic_camera/link/camera/image';;
+    *) print_usage
+       exit 1 ;;
+  esac
+done
+
+GAZEBO_PLUGIN_PATH=$GAZEBO_PLUGIN_PATH:$(dirname "$0") gazebo --verbose $world_file & ./gazebo_tank $display_flag $camera_url

--- a/examples/gazebo_tank/simple_camera/model.config
+++ b/examples/gazebo_tank/simple_camera/model.config
@@ -1,0 +1,11 @@
+<?xml version="1.0" ?>
+<model>
+    <name>simple_camera</name>
+    <version>1.0</version>
+    <sdf version="1.6">model.sdf</sdf>
+    <author>
+        <name>Shinjan Mitra</name>
+        <email>shinjanxp@gmail.com</email>
+    </author>
+    <description>Simple RGB camera</description>
+</model>

--- a/examples/gazebo_tank/simple_camera/model.sdf
+++ b/examples/gazebo_tank/simple_camera/model.sdf
@@ -1,0 +1,70 @@
+<?xml version='1.0'?>
+<sdf version='1.6'>
+  <model name="simple_camera">
+     <pose frame=''>-1.07303 0 0.28895 0 0 3.14159</pose>
+    <link name="link">
+      <inertial>
+        <mass>0.1</mass>
+      </inertial>
+      <collision name="collision">
+        <geometry>
+          <box>
+            <size>0.1 0.1 0.1</size>
+          </box>
+        </geometry>
+      </collision>
+      <visual name="visual">
+        <geometry>
+          <box>
+            <size>0.1 0.1 0.1</size>
+          </box>
+        </geometry>
+      </visual>
+      <sensor name="camera" type="camera">
+        <camera>
+          <horizontal_fov>1.047</horizontal_fov>
+          <image>
+            <width>640</width>
+            <height>480</height>
+          </image>
+          <clip>
+            <near>0.1</near>
+            <far>100</far>
+          </clip>
+          <lens>
+            <type>custom</type>
+            <scale_to_hfov>true</scale_to_hfov>
+            <cutoff_angle>3.1415</cutoff_angle>
+            <env_texture_size>512</env_texture_size>
+            <custom_function>
+              <c1>1.05</c1>
+              <c2>4</c2>
+              <f>1.0</f>
+              <fun>tan</fun>
+            </custom_function>
+          </lens>
+        </camera>
+        <always_on>1</always_on>
+        <update_rate>30</update_rate>
+      </sensor>
+    </link>
+    <joint name='link_0_JOINT_0_0' type='fixed'>
+      <parent>differential_drive_robot::link_0</parent>
+      <child>simple_camera::link</child>
+      <pose frame=''>0 0 0 0 -0 0</pose>
+      <physics>
+        <ode>
+          <limit>
+            <cfm>0</cfm>
+            <erp>0.2</erp>
+          </limit>
+          <suspension>
+            <cfm>0</cfm>
+            <erp>0.2</erp>
+          </suspension>
+        </ode>
+      </physics>
+    </joint>
+  </model>
+
+</sdf>

--- a/include/common/gazebo_node.h
+++ b/include/common/gazebo_node.h
@@ -1,10 +1,6 @@
 #pragma once
 // Gazebo includes
-#include <gazebo/gazebo_config.h>
 #include <gazebo/transport/transport.hh>
-#include <gazebo/msgs/msgs.hh>
-#include <gazebo/common/common.hh>
-
 #include <gazebo/gazebo_client.hh>
 
 using namespace gazebo::transport;

--- a/include/video/gazebocamerainput.h
+++ b/include/video/gazebocamerainput.h
@@ -5,7 +5,7 @@
 #include "common/gazebo_node.h"
 #include "input.h"
 #include "common/semaphore.h"
-
+#include "common/logging.h"
 // Gazebo includes
 #include <gazebo/transport/transport.hh>
 
@@ -38,9 +38,8 @@ public:
     /*!
      * \brief Create a video stream using a new transport node
      */
-    GazeboCameraInput(const std::string &topic, const std::string &cameraName = DefaultCameraName)
-    : m_CameraName(cameraName)
-    {
+    GazeboCameraInput(const std::string &topic, const bool isPanoramic = false)
+    : m_IsPanoramic(isPanoramic){
         m_ImageNode = getGazeboNode();
         subscribeToGazeboCamera(topic);
     }
@@ -51,8 +50,8 @@ public:
      * @param topic Gazebo transport topic on which to subscribe
      */
 
-    GazeboCameraInput(gazebo::transport::NodePtr node, const std::string &topic="/gazebo/default/camera/link/camera/image", const std::string &cameraName = DefaultCameraName)
-      : m_CameraName(cameraName), m_ImageNode(node)
+    GazeboCameraInput(gazebo::transport::NodePtr node, const std::string &topic="/gazebo/default/camera/link/camera/image", const bool isPanoramic=false)
+      : m_ImageNode(node), m_IsPanoramic(isPanoramic)
     {
         subscribeToGazeboCamera(topic);
     }
@@ -61,18 +60,18 @@ public:
         // Subscribe to the topic, and register a callback
         m_ImageSub = m_ImageNode->Subscribe(topic, &GazeboCameraInput::OnImageMsg, this);
         LOG_INFO << "Subsribed to "<< topic <<"\n";
-        m_HaveReceivedFrameSemaphore.wait();
     }
     //------------------------------------------------------------------------
     // Video::Input virtuals
     //------------------------------------------------------------------------
     virtual std::string getCameraName() const override
     {
-        return m_CameraName;
+        return m_IsPanoramic ? "gazebo_panoramic_camera" : "gazebo_camera";
     }
 
     virtual cv::Size getOutputSize() const override
     {
+        m_HaveReceivedFrameSemaphore.waitOnce();
         return m_ReceivedImage.size();
     }
 
@@ -81,31 +80,34 @@ public:
         if(!m_HaveReceivedFrames.load())
             return false;
         std::lock_guard<std::mutex> lck(m_Mtx);
-        outFrame = m_ReceivedImage;
+        m_ReceivedImage.copyTo(outFrame);
         // If there's no error, then we have updated frame and so return true
         return true;
     }
 
+    virtual bool needsUnwrapping() const override{
+        return m_IsPanoramic;
+    }
+
 
 private:
-    std::string m_CameraName;
     gazebo::transport::SubscriberPtr m_ImageSub;
     gazebo::transport::NodePtr m_ImageNode;
     cv::Mat m_ReceivedImage;
     std::mutex m_Mtx;
     std::atomic<bool> m_HaveReceivedFrames{ false };
-    Semaphore m_HaveReceivedFrameSemaphore;
+    mutable Semaphore m_HaveReceivedFrameSemaphore;
+    bool m_IsPanoramic;
 
     void OnImageMsg(ConstImageStampedPtr &msg)
     {
         std::lock_guard<std::mutex> lck(m_Mtx);
-
+        m_ReceivedImage.create(msg->image().height(), msg->image().width(), CV_8UC3);
+        memcpy(m_ReceivedImage.data, msg->image().data().c_str(), msg->image().data().length());
         if(!m_HaveReceivedFrames.load()){
             m_HaveReceivedFrames.store(true);
             m_HaveReceivedFrameSemaphore.notify();
         }
-        m_ReceivedImage.create(msg->image().height(), msg->image().width(), CV_8UC3);
-        memcpy(m_ReceivedImage.data, msg->image().data().c_str(), msg->image().data().length());
     }
 }; // GazeboCameraInput
 } // Video


### PR DESCRIPTION
The gazebo_tank example now supports 2 cameras -  the simple camera and a 360-degree camera. The 360-degree camera is intended to simulate the Kodak PixPro SP360, mounted on the top of the robot pointed upwards. The example can be run by executing `./run.sh -p` from the `examples/gazebo_tank` directory. This will also launch a display screen showing the unwrapped panoramic images captured from the 360-degree camera.