### PR TITLE
Add module for interfacing with Python code

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,3 +7,6 @@
 [submodule "third_party/plog"]
 	path = third_party/plog
 	url = ../../SergiusTheBest/plog.git
+[submodule "third_party/wrappy"]
+	path = third_party/wrappy
+	url = ../../alexdewar/wrappy.git

--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -7,6 +7,7 @@
                 "${workspaceFolder}",
                 "${workspaceFolder}/third_party/ev3dev-lang-cpp",
                 "${workspaceFolder}/third_party/plog/include",
+                "${workspaceFolder}/third_party/wrappy/include",
                 "${ARSDK_ROOT}/out/arsdk-native/staging/usr/include",
                 "/usr/include/python3.7m",
                 "/usr/lib/python3.7/site-packages/numpy/core/include",

--- a/examples/ant_world_python/.gitignore
+++ b/examples/ant_world_python/.gitignore
@@ -1,0 +1,1 @@
+/ant_world_python

--- a/examples/ant_world_python/CMakeLists.txt
+++ b/examples/ant_world_python/CMakeLists.txt
@@ -1,0 +1,4 @@
+cmake_minimum_required(VERSION 3.1)
+include(../../cmake/bob_robotics.cmake)
+BoB_project(SOURCES ant_world_python.cc
+            BOB_MODULES antworld python)

--- a/examples/ant_world_python/ant_world_python.cc
+++ b/examples/ant_world_python/ant_world_python.cc
@@ -64,6 +64,11 @@ main(int argc, char **argv)
 
         // Read frame
         agent.readFrame(im);
+
+        /*
+         * Call python function. Remember that npArray points to the same data
+         * as im.
+         */
         Python::call("ant_world_python.my_function", npArray);
     }
 }

--- a/examples/ant_world_python/ant_world_python.cc
+++ b/examples/ant_world_python/ant_world_python.cc
@@ -1,0 +1,69 @@
+// BoB robotics includes
+#include "antworld/agent.h"
+#include "antworld/route_continuous.h"
+#include "python/python.h"
+
+// Third-party includes
+#include "third_party/units.h"
+
+// Standard C includes
+#include <cstdlib>
+
+using namespace BoBRobotics;
+using namespace units::angle;
+using namespace units::length;
+
+int
+main(int argc, char **argv)
+{
+    /*
+     * I've set the width of the image to be the same as the (raw) unwrapped
+     * images we get from the robot gantry, but the height is greater (cf. 58)
+     * because I wanted to keep the aspect ratio as it was (200x40).
+     *      -- AD
+     */
+    const cv::Size RenderSize{ 720, 150 };
+    constexpr meter_t AgentHeight = 1_cm;
+    constexpr meter_t PathStep = 1_cm;
+
+    auto window = AntWorld::AntAgent::initialiseWindow(RenderSize);
+    const auto executableDir = filesystem::path(argv[0]).parent_path();
+
+    filesystem::path routePath;
+    if (argc > 1)
+        routePath = argv[1];
+    else {
+        // Load default route
+        routePath = executableDir / ".." / ".." / "resources" / "antworld" / "ant1_route1.bin";
+    }
+
+    // Create route object and load route file specified by command line
+    AntWorld::RouteContinuous route(0.2f, 800);
+    route.load(routePath.str());
+
+    AntWorld::Renderer renderer{ 256, 0.001, 1000.0, 360_deg };
+    renderer.getWorld().load(executableDir / ".." / ".." / "resources" / "antworld" / "world5000_gray.bin",
+                             { 0.0f, 1.0f, 0.0f },
+                             { 0.898f, 0.718f, 0.353f });
+    AntWorld::AntAgent agent{ *window, renderer, RenderSize };
+
+    agent.setPosition(0_m, 0_m, AgentHeight);
+
+    // Look for python modules in current dir
+    Python::appendToPythonPath(executableDir);
+    Python::importModule("ant_world_python");
+
+    cv::Mat im{ RenderSize, CV_8UC3 }; // To hold ant's view
+    wrappy::NumpyArray npArray{ im }; // This now points to the data in im
+
+    for (auto distance = 0_m; distance < route.getLength(); distance += PathStep) {
+        // Move agent along route
+        Pose3<meter_t, degree_t> pose = route.getPose(distance);
+        pose.z() = AgentHeight;
+        agent.setPose(pose);
+
+        // Read frame
+        agent.readFrame(im);
+        Python::call("ant_world_python.my_function", npArray);
+    }
+}

--- a/examples/ant_world_python/ant_world_python.py
+++ b/examples/ant_world_python/ant_world_python.py
@@ -1,0 +1,11 @@
+#!/usr/bin/env python
+import cv2
+
+print("Hello from python!")
+
+edges = []
+
+def my_function(np_array):
+    edges = cv2.Canny(np_array, 100, 200)
+    cv2.imshow('Python: Ant' 's view', edges)
+    cv2.waitKeyEx(1)

--- a/include/python/python.h
+++ b/include/python/python.h
@@ -1,0 +1,96 @@
+#pragma once
+
+// Third-party includes
+#include "third_party/path.h"
+#include "wrappy/wrappy.h"
+
+// Numpy
+#define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
+#include <numpy/arrayobject.h>
+
+// OpenCV
+#include <opencv2/opencv.hpp>
+
+// Standard C++ includes
+#include <vector>
+#include <string>
+
+namespace wrappy {
+
+//! Run the specified python script
+void
+runFile(const filesystem::path &filePath);
+
+//! Add the specified directory to the python path
+void
+appendToPythonPath(const filesystem::path &path);
+
+//! Import a new python module
+void
+importModule(const std::string &moduleName);
+
+#if PY_MAJOR_VERSION >= 3
+inline void *
+importNumpy()
+{
+    import_array(); // initialize C-API
+    return nullptr;
+}
+#else
+inline void
+importNumpy()
+{
+    import_array(); // initialize C-API
+}
+#endif
+
+// Type selector for numpy array conversion
+template <typename T> struct NumpyType { const static NPY_TYPES type = NPY_NOTYPE; }; //Default
+template <> struct NumpyType<double> { const static NPY_TYPES type = NPY_DOUBLE; };
+template <> struct NumpyType<float> { const static NPY_TYPES type = NPY_FLOAT; };
+template <> struct NumpyType<bool> { const static NPY_TYPES type = NPY_BOOL; };
+template <> struct NumpyType<int8_t> { const static NPY_TYPES type = NPY_INT8; };
+template <> struct NumpyType<int16_t> { const static NPY_TYPES type = NPY_SHORT; };
+template <> struct NumpyType<int32_t> { const static NPY_TYPES type = NPY_INT; };
+template <> struct NumpyType<int64_t> { const static NPY_TYPES type = NPY_INT64; };
+template <> struct NumpyType<uint8_t> { const static NPY_TYPES type = NPY_UINT8; };
+template <> struct NumpyType<uint16_t> { const static NPY_TYPES type = NPY_USHORT; };
+template <> struct NumpyType<uint32_t> { const static NPY_TYPES type = NPY_ULONG; };
+template <> struct NumpyType<uint64_t> { const static NPY_TYPES type = NPY_UINT64; };
+
+//! A C++ wrapper for creating numpy arrays
+class NumpyArray
+  : public PythonObject
+{
+public:
+    NumpyArray(PyObject *obj);
+
+    //! Create a NumpyArray pointing to the contents of v
+    template<class T>
+    NumpyArray(std::vector<T> &v)
+      : NumpyArray{ getObject(v) }
+    {}
+
+    //! Create a NumpyArray pointing to the contents of mat
+    NumpyArray(cv::Mat &mat);
+
+    //! Get the numpy type of the array
+    static constexpr NPY_TYPES type();
+
+private:
+    template<class T>
+    static PyObject *getObject(std::vector<T> &v)
+    {
+        importNumpy();
+        const npy_intp size = v.size();
+        return PyArray_SimpleNewFromData(1, &size, NumpyType<T>::type,
+                                         static_cast<void *>(v.data()));
+    }
+}; // NumpyArray
+
+} // wrappy
+
+namespace BoBRobotics {
+// Put all of wrappy's functions etc. into BoBRobotics::Python
+namespace Python = wrappy;
+} // BoBRobotics

--- a/include/python/python.h
+++ b/include/python/python.h
@@ -29,7 +29,7 @@ void
 appendToPythonPath(const filesystem::path &path);
 
 //! Import a new python module
-void
+Object
 importModule(const std::string &moduleName);
 
 #if PY_MAJOR_VERSION >= 3

--- a/include/python/python.h
+++ b/include/python/python.h
@@ -17,6 +17,9 @@
 
 namespace wrappy {
 
+//! An alias for wrappy::PythonObject, for brevity's sake
+using Object = PythonObject;
+
 //! Run the specified python script
 void
 runFile(const filesystem::path &filePath);
@@ -60,7 +63,7 @@ template <> struct NumpyType<uint64_t> { const static NPY_TYPES type = NPY_UINT6
 
 //! A C++ wrapper for creating numpy arrays
 class NumpyArray
-  : public PythonObject
+  : public Object
 {
 public:
     NumpyArray(PyObject *obj);

--- a/src/python/CMakeLists.txt
+++ b/src/python/CMakeLists.txt
@@ -1,0 +1,6 @@
+cmake_minimum_required(VERSION 3.1)
+include(../../cmake/bob_robotics.cmake)
+BoB_module(SOURCES python.cc
+           BOB_MODULES common
+           THIRD_PARTY wrappy
+           EXTERNAL_LIBS numpy)

--- a/src/python/python.cc
+++ b/src/python/python.cc
@@ -86,7 +86,7 @@ getObject(cv::Mat &mat)
 }
 
 NumpyArray::NumpyArray(PyObject *obj)
-  : PythonObject{ PythonObject::owning{}, obj }
+  : Object{ Object::owning{}, obj }
 {
     if (!obj) {
         throw std::runtime_error("Could not create numpy array");

--- a/src/python/python.cc
+++ b/src/python/python.cc
@@ -34,12 +34,15 @@ appendToPythonPath(const filesystem::path &path)
     PyRun_SimpleString(runStr.c_str());
 }
 
-void
+Object
 importModule(const std::string &moduleName)
 {
-    if (PyImport_Import(construct(moduleName).get()) == nullptr) {
+    Object module{ Object::owning{},
+                   PyImport_Import(construct(moduleName).get()) };
+    if (!module) {
         throw std::runtime_error("Could not import module " + moduleName);
     }
+    return module;
 }
 
 NPY_TYPES

--- a/src/python/python.cc
+++ b/src/python/python.cc
@@ -1,0 +1,100 @@
+// BoB robotics includes
+#include "python/python.h"
+#include "common/macros.h"
+
+// Standard C includes
+#include <cstdio>
+
+// Standard C++ includes
+#include <stdexcept>
+
+namespace wrappy {
+
+void
+runFile(const filesystem::path &filePath)
+{
+    /*
+     * Apparently we need to read in binary mode so that on Windows, line
+     * endings are handled correctly.
+     */
+    auto filp = fopen(filePath.str().c_str(), "rb");
+
+    // filp will automatically be closed
+    if (PyRun_SimpleFileEx(filp, filePath.str().c_str(), true) != 0) {
+        throw std::runtime_error("Error executing python script: " + filePath.str());
+    }
+}
+
+void
+appendToPythonPath(const filesystem::path &path)
+{
+    const std::string runStr = "import sys\n"
+                               "sys.path.append('" +
+                               path.str() + "')";
+    PyRun_SimpleString(runStr.c_str());
+}
+
+void
+importModule(const std::string &moduleName)
+{
+    if (PyImport_Import(construct(moduleName).get()) == nullptr) {
+        throw std::runtime_error("Could not import module " + moduleName);
+    }
+}
+
+NPY_TYPES
+opencvTypeToNumpyType(int cvType)
+{
+    switch (cvType & CV_MAT_DEPTH_MASK) {
+    case CV_8U:
+        return NPY_UINT8;
+    case CV_8S:
+        return NPY_INT8;
+    case CV_16U:
+        return NPY_UINT16;
+    case CV_16S:
+        return NPY_INT16;
+    case CV_32S:
+        return NPY_INT32;
+    case CV_32F:
+        return NPY_FLOAT32;
+    case CV_64F:
+        return NPY_FLOAT64;
+    default:
+        return NPY_NOTYPE;
+    }
+}
+
+PyObject *
+getObject(cv::Mat &mat)
+{
+    importNumpy();
+    std::vector<npy_intp> size;
+    size.reserve(mat.dims);
+    for (int i = 0; i < mat.dims; i++) {
+        size.push_back(mat.size[i]);
+    }
+
+    // Colour channels are an extra dimension
+    if (mat.channels() > 1) {
+        size.push_back(mat.channels());
+    }
+
+    auto npType = opencvTypeToNumpyType(mat.type());
+    return PyArray_SimpleNewFromData(size.size(), size.data(), npType,
+                                     static_cast<void *>(mat.data));
+}
+
+NumpyArray::NumpyArray(PyObject *obj)
+  : PythonObject{ PythonObject::owning{}, obj }
+{
+    if (!obj) {
+        throw std::runtime_error("Could not create numpy array");
+    }
+}
+
+NumpyArray::NumpyArray(cv::Mat &mat)
+  : NumpyArray{ wrappy::getObject(mat) }
+{}
+
+} // wrappy


### PR DESCRIPTION
I was talking to @efkag and @FullAPVayne about using Ant World recently and I thought it might be worth adding some basic code to call Python functions from BoB robotics projects. (It might also be handy to have a mechanism to call C++ functions from Python -- I did start this but it was a bit of a faff and I got bored.)

It's based on this little library (from the same guy who wrote the matplotlibcpp code): https://github.com/lava/wrappy

I hacked it a bit to add a few features that we needed (notably python 3 support) and I've added a few functions and a ``NumpyArray`` class for passing numpy arrays to Python code (e.g. if you want to pass a ``cv::Mat`` without copying all the data into a Python array first).

I've added an example using the module with Ant World.

@efkag and @FullAPVayne: Does this look usable for you? Is there anything missing?