### PR TITLE
Stop timer being dependant on logging

### DIFF
--- a/include/common/timer.h
+++ b/include/common/timer.h
@@ -1,10 +1,8 @@
 #pragma once
 
-// BoB robotics includes
-#include "logging.h"
-
 // Standard C++ includes
 #include <chrono>
+#include <iostream>
 #include <string>
 
 namespace BoBRobotics {
@@ -23,7 +21,7 @@ public:
     //! Stop the timer and print current elapsed time to terminal
     ~Timer()
     {
-        LOG_INFO << m_Title << get();
+        std::cout << m_Title << get();
     }
 
     //------------------------------------------------------------------------


### PR DESCRIPTION
So, in a lot of my GeNN models, I add ``$(BOB_ROBOTICS_PATH)`` (or, more recently,``$(BOB_ROBOTICS_PATH)/include``) to the include directories in the make files and use a bunch of the header-only stuff in ``genn_utils`` and ``common`` (i.e. timer). However, because of the static initialisation stuff, if ``logging.h`` is included in anything you get linker errors. I'm not sure what the general solution is but my thoughts are:

1. As printing elapsed time is the purpose of the timer rather than some sort of logging information, it should go to ``std::cout`` anyway
2. In header files, "plog/Log.h" rather than "logging.h" should be included.
3. More controversially, aside from in modules with entry points i.e. ``main`` functions, you should include "plog/Log.h" rather than "logging.h" as this allows people to configure plog their own way while still using bob robotics.
4. Does a lot of the stuff in genn_utils actually belong in GeNN (especially the recording helpers)? That would remove the dependency on bob_robotics from a lot of random models which have nothing to do with robotics!

This change currently implements 1, but I'm totally happy to add 2 or 3 if you agree! 4 would need discussing with Thomas but I think it might make sense.