### PR TITLE
Restore ANSI colouring of compiler output

### DIFF
--- a/cmake/bob_robotics.cmake
+++ b/cmake/bob_robotics.cmake
@@ -348,11 +348,11 @@ macro(BoB_build)
     # that output "isn't a terminal" - which seems to include whatever pipe-magick cmake includes.
     # https://medium.com/@alasher/colored-c-compiler-output-with-ninja-clang-gcc-10bfe7f2b949
     if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
-       add_compile_options (-fdiagnostics-color=always)
+       add_compile_flags(-fdiagnostics-color=always)
     elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
-       add_compile_options (-fcolor-diagnostics)
+       add_compile_flags(-fcolor-diagnostics)
     endif ()
-    
+
     # Set include dirs and link libraries for this module/project
     always_included_packages()
     BoB_external_libraries(${PARSED_ARGS_EXTERNAL_LIBS})

--- a/cmake/bob_robotics.cmake
+++ b/cmake/bob_robotics.cmake
@@ -344,6 +344,15 @@ macro(BoB_build)
     set(CMAKE_CXX_STANDARD 14)
     set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
+    # Irritatingly, neither GCC nor Clang produce nice ANSI-coloured output if they detect
+    # that output "isn't a terminal" - which seems to include whatever pipe-magick cmake includes.
+    # https://medium.com/@alasher/colored-c-compiler-output-with-ninja-clang-gcc-10bfe7f2b949
+    if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+       add_compile_options (-fdiagnostics-color=always)
+    elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+       add_compile_options (-fcolor-diagnostics)
+    endif ()
+    
     # Set include dirs and link libraries for this module/project
     always_included_packages()
     BoB_external_libraries(${PARSED_ARGS_EXTERNAL_LIBS})


### PR DESCRIPTION
Irritatingly, neither GCC nor Clang produce nice ANSI-coloured output if they detect that output "isn't a terminal - which seems to include whatever pipe-magick cmake includes.

Curtesy of https://medium.com/@alasher/colored-c-compiler-output-with-ninja-clang-gcc-10bfe7f2b949