### PR TITLE
CMake I2C fix

### DIFF
--- a/cmake/bob_robotics.cmake
+++ b/cmake/bob_robotics.cmake
@@ -352,7 +352,15 @@ macro(BoB_build)
     elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
        add_compile_flags(-fcolor-diagnostics)
     endif ()
-
+    
+    # Different Jetson devices have different user-facing I2C interfaces 
+    # so read the chip ID and add preprocessor macro
+    if(EXISTS /sys/module/tegra_fuse/parameters/tegra_chip_id)
+        file(READ /sys/module/tegra_fuse/parameters/tegra_chip_id TEGRA_CHIP_ID)
+        add_definitions(-DTEGRA_CHIP_ID=${TEGRA_CHIP_ID})
+        message("Tegra chip id: ${TEGRA_CHIP_ID}")
+    endif()
+    
     # Set include dirs and link libraries for this module/project
     always_included_packages()
     BoB_external_libraries(${PARSED_ARGS_EXTERNAL_LIBS})

--- a/cmake/external_libs/i2c.cmake
+++ b/cmake/external_libs/i2c.cmake
@@ -4,7 +4,7 @@ if(${lib} STREQUAL i2c)
         # against an additonal library
         execute_process(COMMAND "${CMAKE_CURRENT_LIST_DIR}/is_i2c_tools_new.sh"
                         RESULT_VARIABLE rv)
-        if(${rv} EQUAL "0")
+        if(${rv} EQUAL 0)
             BoB_add_link_libraries("i2c")
         endif()
     endif()

--- a/cmake/external_libs/i2c.cmake
+++ b/cmake/external_libs/i2c.cmake
@@ -2,7 +2,7 @@ if(${lib} STREQUAL i2c)
     if(NOT WIN32 AND NOT NO_I2C)
         # If it's a new version of i2c-tools then we need to link
         # against an additonal library
-        execute_process(COMMAND "${CMAKE_CURRENT_LIST_DIR}/is_i2c_tools_new.sh"
+        execute_process(COMMAND "${BOB_ROBOTICS_PATH}/bin/is_i2c_tools_new.sh"
                         RESULT_VARIABLE rv)
         if(${rv} EQUAL 0)
             BoB_add_link_libraries("i2c")

--- a/cmake/external_libs/i2c.cmake
+++ b/cmake/external_libs/i2c.cmake
@@ -4,7 +4,7 @@ if(${lib} STREQUAL i2c)
         # against an additonal library
         execute_process(COMMAND "${CMAKE_CURRENT_LIST_DIR}/is_i2c_tools_new.sh"
                         RESULT_VARIABLE rv)
-        if(NOT ${rv} EQUAL 0)
+        if(${rv} EQUAL "0")
             BoB_add_link_libraries("i2c")
         endif()
     endif()

--- a/include/robots/norbot.h
+++ b/include/robots/norbot.h
@@ -8,6 +8,14 @@
 // Third-party includes
 #include "third_party/units.h"
 
+#if TEGRA_CHIP_ID == 33
+    #define USER_I2C_DEVICE "/dev/i2c-1"
+#elif TEGRA_CHIP_ID == 24
+    #define USER_I2C_DEVICE "/dev/i2c-0"
+#else
+    #error Unsupported tegra chip id
+#endif
+
 namespace BoBRobotics {
 namespace Robots {
 //----------------------------------------------------------------------------
@@ -20,7 +28,7 @@ class Norbot : public Tank
     using millimeter_t = units::length::millimeter_t;
 
 public:
-    Norbot(const char *path = "/dev/i2c-1", int slaveAddress = 0x29);
+    Norbot(const char *path = USER_I2C_DEVICE, int slaveAddress = 0x29);
 
     //----------------------------------------------------------------------------
     // Tank virtuals

--- a/include/robots/norbot.h
+++ b/include/robots/norbot.h
@@ -14,9 +14,8 @@
 // Whereas, on Jetson TX2, I2C bus 0 is the one broken out
 #elif TEGRA_CHIP_ID == 24
     #define I2C_DEVICE_DEFAULT "/dev/i2c-0"
-// Otherwise, use /dev/null and give warning
+// Otherwise, use /dev/null
 #else
-    //#warning Using Norbot on unknown device - I2C device should be manually set
     #define I2C_DEVICE_DEFAULT "/dev/null"
 #endif
 

--- a/include/robots/norbot.h
+++ b/include/robots/norbot.h
@@ -8,12 +8,16 @@
 // Third-party includes
 #include "third_party/units.h"
 
+// If we're on Jetson TX1, I2C bus 1 is the one broken out
 #if TEGRA_CHIP_ID == 33
-    #define USER_I2C_DEVICE "/dev/i2c-1"
+    #define I2C_DEVICE_DEFAULT "/dev/i2c-1"
+// Whereas, on Jetson TX2, I2C bus 0 is the one broken out
 #elif TEGRA_CHIP_ID == 24
-    #define USER_I2C_DEVICE "/dev/i2c-0"
+    #define I2C_DEVICE_DEFAULT "/dev/i2c-0"
+// Otherwise, use /dev/null and give warning
 #else
-    #error Unsupported tegra chip id
+    //#warning Using Norbot on unknown device - I2C device should be manually set
+    #define I2C_DEVICE_DEFAULT "/dev/null"
 #endif
 
 namespace BoBRobotics {
@@ -28,7 +32,7 @@ class Norbot : public Tank
     using millimeter_t = units::length::millimeter_t;
 
 public:
-    Norbot(const char *path = USER_I2C_DEVICE, int slaveAddress = 0x29);
+    Norbot(const char *path = I2C_DEVICE_DEFAULT, int slaveAddress = 0x29);
 
     //----------------------------------------------------------------------------
     // Tank virtuals


### PR DESCRIPTION
This test was implemented backwards in the cmake version (see https://github.com/BrainsOnBoard/bob_robotics/blob/norbot_navigation/common/flags.mk#L94)