### PR TITLE
-Wno-deprecated-copy doesn't exist on GCC earlier than 9

### DIFF
--- a/cmake/bob_robotics.cmake
+++ b/cmake/bob_robotics.cmake
@@ -322,7 +322,9 @@ macro(BoB_build)
         #
         # Eigen version: 3.3.7
         # gcc version:   9.1.0
-        add_compile_flags(-Wno-deprecated-copy)
+        if (CMAKE_COMPILER_IS_GNUCC AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 9.0)
+            add_compile_flags(-Wno-deprecated-copy)
+        endif()
 
         # Disable optimisation for debug builds
         set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -O0")


### PR DESCRIPTION
Gets rid of annoying warnings on my GCC 7