### PR TITLE
CMake Bebop fix

### DIFF
--- a/cmake/bob_robotics.cmake
+++ b/cmake/bob_robotics.cmake
@@ -148,6 +148,13 @@ macro(BoB_project)
     # Do linking etc.
     BoB_build()
 
+    # When using the ARSDK (Parrot Bebop SDK) the rpath is not correctly set on
+    # Ubuntu (and presumably when linking against other libs in non-standard
+    # locations too). This linker flag fixes the problem.
+    if(UNIX)
+        set(CMAKE_EXE_LINKER_FLAGS -Wl,--disable-new-dtags)
+    endif()
+
     # Copy all DLLs over from vcpkg dir. We don't necessarily need all of them,
     # but it would be a hassle to figure out which ones we need.
     if(WIN32)
@@ -354,15 +361,15 @@ macro(BoB_build)
     elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
        add_compile_flags(-fcolor-diagnostics)
     endif ()
-    
-    # Different Jetson devices have different user-facing I2C interfaces 
+
+    # Different Jetson devices have different user-facing I2C interfaces
     # so read the chip ID and add preprocessor macro
     if(EXISTS /sys/module/tegra_fuse/parameters/tegra_chip_id)
         file(READ /sys/module/tegra_fuse/parameters/tegra_chip_id TEGRA_CHIP_ID)
         add_definitions(-DTEGRA_CHIP_ID=${TEGRA_CHIP_ID})
         message("Tegra chip id: ${TEGRA_CHIP_ID}")
     endif()
-    
+
     # Set include dirs and link libraries for this module/project
     always_included_packages()
     BoB_external_libraries(${PARSED_ARGS_EXTERNAL_LIBS})

--- a/src/robots/bebop/CMakeLists.txt
+++ b/src/robots/bebop/CMakeLists.txt
@@ -4,10 +4,6 @@ BoB_module_custom(SOURCES bebop.cc video.cc
                   BOB_MODULES robots hid video common
                   PLATFORMS unix)
 
-# CMake doesn't pass this flag automatically and without it the ARSDK libs
-# aren't found at runtime
-set(CMAKE_EXE_LINKER_FLAGS "-Wl,--disable-new-tags")
-
 # We need to know where ARSDK is installed
 if(NOT DEFINED ENV{ARSDK_ROOT})
     message(FATAL_ERROR "The ARSDK_ROOT environment variable is not set")


### PR DESCRIPTION
This is a minor CMake fix for the robots/bebop module.

It seems that on Ubuntu the rpath (to find the ARSDK libs) isn't set correctly, just the runpath (I forget what the proper distinction is), so the ARSDK libs aren't found when running programs using this module. Adding the ``--disable-new-dtags`` flag to the linker for all programs fixes things. I tried just setting it for programs using the robots/bebop module but for some reason this doesn't work.