### PR TITLE
Set BoB robotics path at compile time

### DIFF
--- a/cmake/bob_robotics.cmake
+++ b/cmake/bob_robotics.cmake
@@ -354,15 +354,15 @@ macro(BoB_build)
     elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
        add_compile_flags(-fcolor-diagnostics)
     endif ()
-    
-    # Different Jetson devices have different user-facing I2C interfaces 
+
+    # Different Jetson devices have different user-facing I2C interfaces
     # so read the chip ID and add preprocessor macro
     if(EXISTS /sys/module/tegra_fuse/parameters/tegra_chip_id)
         file(READ /sys/module/tegra_fuse/parameters/tegra_chip_id TEGRA_CHIP_ID)
         add_definitions(-DTEGRA_CHIP_ID=${TEGRA_CHIP_ID})
         message("Tegra chip id: ${TEGRA_CHIP_ID}")
     endif()
-    
+
     # Set include dirs and link libraries for this module/project
     always_included_packages()
     BoB_external_libraries(${PARSED_ARGS_EXTERNAL_LIBS})
@@ -556,7 +556,7 @@ if (${CMAKE_SOURCE_DIR} STREQUAL ${CMAKE_BINARY_DIR})
 endif()
 
 # Set output directories for libs and executables
-set(BOB_ROBOTICS_PATH "${CMAKE_CURRENT_LIST_DIR}/..")
+get_filename_component(BOB_ROBOTICS_PATH .. ABSOLUTE BASE_DIR "${CMAKE_CURRENT_LIST_DIR}")
 
 # If this var is defined then this project is being included in another build
 if(NOT DEFINED BOB_DIR)

--- a/cmake/bob_robotics.cmake
+++ b/cmake/bob_robotics.cmake
@@ -270,6 +270,10 @@ macro(BoB_build)
         add_definitions(-DNO_I2C)
     endif()
 
+    # Add macro so that programs know where the root folder is for e.g. loading
+    # resources
+    add_definitions(-DBOB_ROBOTICS_PATH "${BOB_ROBOTICS_PATH}")
+
     # Default to building release type
     if (NOT CMAKE_BUILD_TYPE)
         set(CMAKE_BUILD_TYPE "Release" CACHE STRING "" FORCE)

--- a/src/common/path.cc
+++ b/src/common/path.cc
@@ -16,16 +16,7 @@ namespace Path {
 filesystem::path
 getRepoPath()
 {
-#ifdef BOB_ROBOTICS_SUBMODULE_PATH
-    return filesystem::path{ BOB_TO_STRING_LITERAL(BOB_ROBOTICS_SUBMODULE_PATH) };
-#else
-    // Get from environment variable
-    const char *path = std::getenv("BOB_ROBOTICS_PATH");
-    if (!path) {
-        throw std::runtime_error("BOB_ROBOTICS_PATH environment variable not set");
-    }
-    return path;
-#endif
+    return filesystem::path{ BOB_TO_STRING_LITERAL(BOB_ROBOTICS_PATH) };
 }
 
 filesystem::path


### PR DESCRIPTION
I think it probably makes more sense to set this at compile time. You do lose the flexibility of being able to change it at runtime, but realistically you're only going to be using one BoB robotics repo for your program at any one time anyway.