### PR TITLE
Turned on LFS and added Seville environment

### DIFF
--- a/resources/antworld/.gitattributes
+++ b/resources/antworld/.gitattributes
@@ -1,0 +1,1 @@
+seville_vegetation_downsampled.obj filter=lfs diff=lfs merge=lfs -text

--- a/resources/antworld/seville_vegetation_downsampled.obj
+++ b/resources/antworld/seville_vegetation_downsampled.obj
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c76b0cdd6b1ec759322f8abe495040f3577a5014586a17d6c2d57230731f0b46
+size 198802799


### PR DESCRIPTION
I'm bored of having to keep scping it between my machines and send google drive links to everyone so I think it makes sense to add the (slightly-postprocessed) version of this environment to bob robotics. It's already online at https://insectvision.dlr.de/3d-reconstruction-tools/habitat3d so I can't see why it would be an issue