### PR TITLE
Ardin MB fixes

### DIFF
--- a/include/antworld/world.h
+++ b/include/antworld/world.h
@@ -63,6 +63,9 @@ public:
         return m_MaxBound;
     }
 
+    void setMinBound(const Vector3<meter_t> &minBound){ m_MinBound = minBound; }
+    void setMaxBound(const Vector3<meter_t> &maxBound){ m_MaxBound = maxBound; }
+
 private:
     //------------------------------------------------------------------------
     // Private methods

--- a/include/genn_utils/connectors.h
+++ b/include/genn_utils/connectors.h
@@ -1,7 +1,8 @@
 #pragma once
 
 // BoB robotics includes
-#include "../common/macros.h"
+#include "common/logging.h"
+#include "common/macros.h"
 
 // Standard C++ includes
 #include <algorithm>

--- a/projects/ardin_mb/CMakeLists.txt
+++ b/projects/ardin_mb/CMakeLists.txt
@@ -1,9 +1,14 @@
 cmake_minimum_required(VERSION 3.1)
 include(../../cmake/bob_robotics.cmake)
-BoB_project(EXECUTABLE ardin_mb
-            SOURCES ardin_mb.cc state_handler.cc mb_memory.cc vector_field.cc
-            GENN_MODEL model.cc
-            BOB_MODULES common antworld navigation)
 
-# Kludge to stop Logger::logger being defined multiple times
-add_definitions(-DNO_HEADER_DEFINITIONS)
+if(NO_GENN)
+    add_definitions(-DNO_GENN)
+    BoB_project(EXECUTABLE ardin_mb
+                SOURCES ardin_mb.cc state_handler.cc vector_field.cc
+                BOB_MODULES common antworld navigation)
+else()
+    BoB_project(EXECUTABLE ardin_mb
+                SOURCES ardin_mb.cc state_handler.cc mb_memory.cc vector_field.cc
+                GENN_MODEL model.cc
+                BOB_MODULES common antworld navigation)
+endif()

--- a/projects/ardin_mb/ardin_mb.cc
+++ b/projects/ardin_mb/ardin_mb.cc
@@ -89,6 +89,15 @@ int main(int argc, char *argv[])
     // Loop until window should close
     sf::Event event;
     for (unsigned int frame = 0; window.isOpen(); frame++) {
+        // Process events
+        sf::Event event;
+        while (window.pollEvent(event)) {
+            // Close window: exit
+            if (event.type == sf::Event::Closed) {
+                window.close();
+            }
+        }
+
         // Clear colour and depth buffer
         glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
 

--- a/projects/ardin_mb/ardin_mb.cc
+++ b/projects/ardin_mb/ardin_mb.cc
@@ -55,6 +55,7 @@ int main(int argc, char *argv[])
     glLineWidth(4.0);
     glPointSize(4.0);
 
+    Logging::Logger::getInstance();
     // Create memory
 #ifdef NO_GENN
     Navigation::PerfectMemory<> memory(cv::Size(MBParams::inputWidth, MBParams::inputHeight));
@@ -68,17 +69,22 @@ int main(int argc, char *argv[])
     std::string routeFilename = "";
     std::string logFilename = "";
     float heightMetres = 0.01f;
+    std::vector<float> minBound;
+    std::vector<float> maxBound;
 
     CLI::App app{"Mushroom body navigation model"};
     app.add_option("--world", worldFilename, "File to load world from", true);
     app.add_option("--height", heightMetres, "Height in metres to navigate at", true);
+    app.add_option("--min-bound", minBound, "Override default world min bound with this one", true)->expected(3);
+    app.add_option("--max-bound", maxBound, "Override default world max bound with this one", true)->expected(3);
     app.add_option("route", routeFilename, "Filename of route");
 
     // Parse command line arguments
     CLI11_PARSE(app, argc, argv);
 
     // Create state machine
-    StateHandler stateHandler(worldFilename, routeFilename, units::length::meter_t{heightMetres}, memory);
+    StateHandler stateHandler(worldFilename, routeFilename, units::length::meter_t{heightMetres},
+                              minBound, maxBound, memory);
 
     // Loop until window should close
     sf::Event event;

--- a/projects/ardin_mb/ardin_mb.cc
+++ b/projects/ardin_mb/ardin_mb.cc
@@ -112,7 +112,7 @@ int main(int argc, char *argv[])
                 stateHandler.setKeyState(StateHandler::KeyTrainSnapshot, pressed);
                 break;
 
-            case sf::Keyboard::Key::Enter:
+            case sf::Keyboard::Key::Return:
                 stateHandler.setKeyState(StateHandler::KeyTestSnapshot, pressed);
                 break;
 

--- a/projects/ardin_mb/ardin_mb.cc
+++ b/projects/ardin_mb/ardin_mb.cc
@@ -34,6 +34,26 @@ using namespace BoBRobotics;
 
 int main(int argc, char *argv[])
 {
+    // Default parameters"
+    std::string worldFilename = "";
+    std::string routeFilename = "";
+    std::string logFilename = "";
+    float heightMetres = 0.01f;
+    std::vector<float> minBound;
+    std::vector<float> maxBound;
+    std::vector<float> clearColour{0.0f, 1.0f, 1.0f, 1.0f};
+
+    CLI::App app{"Mushroom body navigation model"};
+    app.add_option("--world", worldFilename, "File to load world from", true);
+    app.add_option("--height", heightMetres, "Height in metres to navigate at", true);
+    app.add_option("--min-bound", minBound, "Override default world min bound with this one", true)->expected(3);
+    app.add_option("--max-bound", maxBound, "Override default world max bound with this one", true)->expected(3);
+    app.add_option("--clear-colour", clearColour, "Set background colour used for rendering", true)->expected(4);
+    app.add_option("route", routeFilename, "Filename of route");
+
+    // Parse command line arguments
+    CLI11_PARSE(app, argc, argv);
+
     // Create SFML window
     sf::Window window(sf::VideoMode(SimParams::displayRenderWidth, SimParams::displayRenderHeight + SimParams::displayRenderWidth + 10),
                       "Ant world",
@@ -49,13 +69,12 @@ int main(int argc, char *argv[])
         return EXIT_FAILURE;
     }
 
-    // Set clear colour to match matlab and enable depth test
-    glClearColor(0.0f, 1.0f, 1.0f, 1.0f);
+    // Tweak OpenGL settings
+    glClearColor(clearColour[0], clearColour[1], clearColour[2], clearColour[3]);
     glEnable(GL_DEPTH_TEST);
     glLineWidth(4.0);
     glPointSize(4.0);
 
-    Logging::Logger::getInstance();
     // Create memory
 #ifdef NO_GENN
     Navigation::PerfectMemory<> memory(cv::Size(MBParams::inputWidth, MBParams::inputHeight));
@@ -64,23 +83,7 @@ int main(int argc, char *argv[])
     MBMemory memory;
 #endif
 
-     // Default parameters"
-    std::string worldFilename = "";
-    std::string routeFilename = "";
-    std::string logFilename = "";
-    float heightMetres = 0.01f;
-    std::vector<float> minBound;
-    std::vector<float> maxBound;
 
-    CLI::App app{"Mushroom body navigation model"};
-    app.add_option("--world", worldFilename, "File to load world from", true);
-    app.add_option("--height", heightMetres, "Height in metres to navigate at", true);
-    app.add_option("--min-bound", minBound, "Override default world min bound with this one", true)->expected(3);
-    app.add_option("--max-bound", maxBound, "Override default world max bound with this one", true)->expected(3);
-    app.add_option("route", routeFilename, "Filename of route");
-
-    // Parse command line arguments
-    CLI11_PARSE(app, argc, argv);
 
     // Create state machine
     StateHandler stateHandler(worldFilename, routeFilename, units::length::meter_t{heightMetres},

--- a/projects/ardin_mb/ardin_mb.cc
+++ b/projects/ardin_mb/ardin_mb.cc
@@ -90,7 +90,6 @@ int main(int argc, char *argv[])
     sf::Event event;
     for (unsigned int frame = 0; window.isOpen(); frame++) {
         // Process events
-        sf::Event event;
         while (window.pollEvent(event)) {
             // Close window: exit
             if (event.type == sf::Event::Closed) {

--- a/projects/ardin_mb/ardin_mb.cc
+++ b/projects/ardin_mb/ardin_mb.cc
@@ -57,14 +57,16 @@ int main(int argc, char *argv[])
     glPointSize(4.0);
 
     // Create memory
-    //Navigation::PerfectMemory<> memory(cv::Size(MBParams::inputWidth, MBParams::inputHeight));
+#ifdef NO_GENN
+    Navigation::PerfectMemory<> memory(cv::Size(MBParams::inputWidth, MBParams::inputHeight));
     //Navigation::InfoMax<float> memory(cv::Size(MBParams::inputWidth, MBParams::inputHeight), 0.01f);
+#else
     MBMemory memory;
-
+#endif
     // Create state machine and set it as window user pointer
     const auto worldFilename = Path::getResourcesPath() / "antworld" / "world5000_gray.bin";
     const std::string routeFilename = (argc > 1) ? argv[1] : "";
-    StateHandler stateHandler(worldFilename, routeFilename, memory);
+    StateHandler stateHandler(worldFilename.str(), routeFilename, memory);
 
     // Loop until window should close
     sf::Event event;

--- a/projects/ardin_mb/ardin_mb.cc
+++ b/projects/ardin_mb/ardin_mb.cc
@@ -95,6 +95,56 @@ int main(int argc, char *argv[])
             if (event.type == sf::Event::Closed) {
                 window.close();
             }
+            // Key events
+            else if(event.type == sf::Event::KeyPressed || event.type == sf::Event::KeyReleased) {
+                const bool pressed = event.type == sf::Event::KeyPressed;
+
+                // Apply new key state to bits of key bits
+                switch(event.key.code) {
+                    case sf::Keyboard::Key::Left:
+                        stateHandler.setKeyState(StateHandler::KeyLeft, pressed);
+                        break;
+
+                    case sf::Keyboard::Key::Right:
+                        stateHandler.setKeyState(StateHandler::KeyRight, pressed);
+                        break;
+
+                    case sf::Keyboard::Key::Up:
+                        stateHandler.setKeyState(StateHandler::KeyUp, pressed);
+                        break;
+
+                    case sf::Keyboard::Key::Down:
+                        stateHandler.setKeyState(StateHandler::KeyDown, pressed);
+                        break;
+
+                    case sf::Keyboard::Key::R:
+                        stateHandler.setKeyState(StateHandler::KeyReset, pressed);
+                        break;
+
+                    case sf::Keyboard::Key::Space:
+                        stateHandler.setKeyState(StateHandler::KeyTrainSnapshot, pressed);
+                        break;
+
+                    case sf::Keyboard::Key::Return:
+                        stateHandler.setKeyState(StateHandler::KeyTestSnapshot, pressed);
+                        break;
+
+                    case sf::Keyboard::Key::S:
+                        stateHandler.setKeyState(StateHandler::KeySaveSnapshot, pressed);
+                        break;
+
+                    case sf::Keyboard::Key::W:
+                        stateHandler.setKeyState(StateHandler::KeyRandomWalk, pressed);
+                        break;
+
+                    case sf::Keyboard::Key::V:
+                        stateHandler.setKeyState(StateHandler::KeyBuildVectorField, pressed);
+                        break;
+
+                    default:
+                        break;
+                }
+            }
         }
 
         // Clear colour and depth buffer
@@ -107,56 +157,6 @@ int main(int argc, char *argv[])
 
         // Swap front and back buffers
         window.display();
-
-        // Poll for and process events
-        if (window.pollEvent(event) && (event.type == sf::Event::KeyPressed || event.type == sf::Event::KeyReleased)) {
-            const bool pressed = event.type == sf::Event::KeyPressed;
-
-            // Apply new key state to bits of key bits
-            switch(event.key.code) {
-            case sf::Keyboard::Key::Left:
-                stateHandler.setKeyState(StateHandler::KeyLeft, pressed);
-                break;
-
-            case sf::Keyboard::Key::Right:
-                stateHandler.setKeyState(StateHandler::KeyRight, pressed);
-                break;
-
-            case sf::Keyboard::Key::Up:
-                stateHandler.setKeyState(StateHandler::KeyUp, pressed);
-                break;
-
-            case sf::Keyboard::Key::Down:
-                stateHandler.setKeyState(StateHandler::KeyDown, pressed);
-                break;
-
-            case sf::Keyboard::Key::R:
-                stateHandler.setKeyState(StateHandler::KeyReset, pressed);
-                break;
-
-            case sf::Keyboard::Key::Space:
-                stateHandler.setKeyState(StateHandler::KeyTrainSnapshot, pressed);
-                break;
-
-            case sf::Keyboard::Key::Return:
-                stateHandler.setKeyState(StateHandler::KeyTestSnapshot, pressed);
-                break;
-
-            case sf::Keyboard::Key::S:
-                stateHandler.setKeyState(StateHandler::KeySaveSnapshot, pressed);
-                break;
-
-            case sf::Keyboard::Key::W:
-                stateHandler.setKeyState(StateHandler::KeyRandomWalk, pressed);
-                break;
-
-            case sf::Keyboard::Key::V:
-                stateHandler.setKeyState(StateHandler::KeyBuildVectorField, pressed);
-                break;
-            default:
-                break;
-            }
-        }
     }
 
     return 0;

--- a/projects/ardin_mb/ardin_mb.cc
+++ b/projects/ardin_mb/ardin_mb.cc
@@ -1,8 +1,4 @@
-// This is the main file, so we do want header definitions for this object
-#undef NO_HEADER_DEFINITIONS
-
 // BoB Robotics includes
-#include "common/path.h"
 #include "common/logging.h"
 #include "navigation/infomax.h"
 #include "navigation/perfect_memory.h"
@@ -12,6 +8,9 @@
 #include "mb_params.h"
 #include "sim_params.h"
 #include "state_handler.h"
+
+// CLI11 includes
+#include "third_party/CLI11.hpp"
 
 // OpenGL includes
 #include <GL/glew.h>
@@ -63,10 +62,23 @@ int main(int argc, char *argv[])
 #else
     MBMemory memory;
 #endif
-    // Create state machine and set it as window user pointer
-    const auto worldFilename = Path::getResourcesPath() / "antworld" / "world5000_gray.bin";
-    const std::string routeFilename = (argc > 1) ? argv[1] : "";
-    StateHandler stateHandler(worldFilename.str(), routeFilename, memory);
+
+     // Default parameters"
+    std::string worldFilename = "";
+    std::string routeFilename = "";
+    std::string logFilename = "";
+    float heightMetres = 0.01f;
+
+    CLI::App app{"Mushroom body navigation model"};
+    app.add_option("--world", worldFilename, "File to load world from", true);
+    app.add_option("--height", heightMetres, "Height in metres to navigate at", true);
+    app.add_option("route", routeFilename, "Filename of route");
+
+    // Parse command line arguments
+    CLI11_PARSE(app, argc, argv);
+
+    // Create state machine
+    StateHandler stateHandler(worldFilename, routeFilename, units::length::meter_t{heightMetres}, memory);
 
     // Loop until window should close
     sf::Event event;

--- a/projects/ardin_mb/state_handler.cc
+++ b/projects/ardin_mb/state_handler.cc
@@ -20,6 +20,7 @@ using namespace units::length;
 // StateHandler
 //----------------------------------------------------------------------------
 StateHandler::StateHandler(const std::string &worldFilename, const std::string &routeFilename, meter_t pathHeight,
+                           const std::vector<float> &minBound, const std::vector<float> &maxBound,
                            BoBRobotics::Navigation::VisualNavigationBase &visualNavigation)
 :   m_StateMachine(this, State::Invalid), m_Snapshot(SimParams::displayRenderHeight, SimParams::displayRenderWidth, CV_8UC3),
     m_Input({ SimParams::displayRenderWidth, SimParams::displayRenderHeight }, { 0, SimParams::displayRenderWidth + 10 }), m_Route(0.2f, 800),
@@ -34,6 +35,15 @@ StateHandler::StateHandler(const std::string &worldFilename, const std::string &
     }
     else {
         m_Renderer.getWorld().loadObj(worldFilename);
+    }
+
+    // Override world bounds if they are specified
+    if(!minBound.empty()) {
+        m_Renderer.getWorld().setMinBound(Vector3<meter_t>(meter_t(minBound[0]), meter_t(minBound[1]), meter_t(minBound[2])));
+    }
+
+    if(!maxBound.empty()) {
+        m_Renderer.getWorld().setMaxBound(Vector3<meter_t>(meter_t(maxBound[0]), meter_t(maxBound[1]), meter_t(maxBound[2])));
     }
 
     // If route is specified

--- a/projects/ardin_mb/state_handler.cc
+++ b/projects/ardin_mb/state_handler.cc
@@ -73,7 +73,7 @@ bool StateHandler::handleEvent(State state, Event event)
     if(event == Event::Update) {
 
         // Render top down and ants eye view
-        m_Renderer.renderPanoramicView(m_Pose.y(), m_Pose.x(), m_PathHeight,
+        m_Renderer.renderPanoramicView(m_Pose.x(), m_Pose.y(), m_PathHeight,
                                        m_Pose.yaw(), 0.0_deg, 0.0_deg,
                                        0, SimParams::displayRenderWidth + 10, SimParams::displayRenderWidth, SimParams::displayRenderHeight);
         m_Renderer.renderTopDownView(0, 0, SimParams::displayRenderWidth, SimParams::displayRenderWidth);

--- a/projects/ardin_mb/state_handler.h
+++ b/projects/ardin_mb/state_handler.h
@@ -73,7 +73,7 @@ public:
         KeyMax
     };
 
-    StateHandler(const std::string &worldFilename, const std::string &routeFilename,
+    StateHandler(const std::string &worldFilename, const std::string &routeFilename, meter_t pathHeight,
                  BoBRobotics::Navigation::VisualNavigationBase &visualNavigation);
 
     //------------------------------------------------------------------------
@@ -159,6 +159,9 @@ private:
 
     //! Distribution of angles to turn for random walk
     std::uniform_real_distribution<float> m_RandomWalkAngleDistribution;
+
+    //! Height of path
+    const meter_t m_PathHeight;
 
     //! Model used for visual navigation
     BoBRobotics::Navigation::VisualNavigationBase &m_VisualNavigation;

--- a/projects/ardin_mb/state_handler.h
+++ b/projects/ardin_mb/state_handler.h
@@ -74,6 +74,7 @@ public:
     };
 
     StateHandler(const std::string &worldFilename, const std::string &routeFilename, meter_t pathHeight,
+                 const std::vector<float> &minBound, const std::vector<float> &maxBound,
                  BoBRobotics::Navigation::VisualNavigationBase &visualNavigation);
 
     //------------------------------------------------------------------------

--- a/src/antworld/renderer.cc
+++ b/src/antworld/renderer.cc
@@ -236,12 +236,14 @@ void Renderer::renderTopDownView(GLint viewportX, GLint viewportY, GLsizei viewp
     // **TODO** re-implement in Eigen
     glMatrixMode(GL_PROJECTION);
     glLoadIdentity();
-    gluOrtho2D(minBound[0].value(), maxBound[0].value(),
-               minBound[1].value(), maxBound[1].value());
+    glOrtho(minBound[0].value(), maxBound[0].value(),
+            minBound[1].value(), maxBound[1].value(),
+            -1.0, maxBound[2].value() - minBound[2].value());
 
     // Build modelview matrix to centre world
     glMatrixMode(GL_MODELVIEW);
     glLoadIdentity();
+    glScalef(1.0f, 1.0f, -1.0f);
 
     // Render geometry
     renderTopDownGeometry();


### PR DESCRIPTION
As you witnessed, the version of this project in master wasn't in a state where it could easily be used for anything (apologies @FullAPVayne)! This P.R. fixes the following:
- Adds a CMake option ``NO_GENN`` which doesn't build the GeNN mushroom body and defaults to using the mushroom body
- Fixed outdated SFML key enum
- Fixed incorrect SFML event processing (you couldn't close the window)
- Added a proper CLI using CLI11 to enable you to load different world models and tweak the bits required to make it work with them e.g. loads the new seville ant world model in such a way that it works
  ``./ardin_mb --world ../../resources/antworld/seville_vegetation_downsampled.obj --height 1.6 --min-bound 0 0 0 --max-bound 10 10 2.8 --clear-colour 0.8 0.8 0.8 1.0``
- Tweaked the way the top-down view gets rendered - there was a weird swapping of x and y in the previous rendering code which definitely shouldn't have been there and I am 90% the answer was that it was rendering the world upside down
- Tweaked the clipping when rendering the world top-down so big environments don't get clipped