### PR TITLE
Automatically delete old builds on Jenkins

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,12 @@
 #!groovy​
 
+// only keep 100 builds to prevent disk usage from growing out of control
+properties([
+    buildDiscarder(logRotator(artifactDaysToKeepStr: '', 
+                              artifactNumToKeepStr: '', 
+                              daysToKeepStr: '', 
+                              numToKeepStr: '100'))])
+                              
 //--------------------------------------------------------------------------
 // Helper functions
 //--------------------------------------------------------------------------


### PR DESCRIPTION
I noticed that the Jenkins server is basically out of disk space. I did some manual deleting of old build but this **should** set some automatic build discarding rules based on https://stackoverflow.com/questions/47778019/how-to-use-options-in-a-jenkins-scripted-pipeline - if you think archiving the 100 latest builds isn't ideal, feel free to change