### PR TITLE
Add support for C++17 and Gazebo v11+

### DIFF
--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -14,9 +14,11 @@
                 "/usr/include/opencv4",
                 "/usr/include/gazebo-9",
                 "/usr/include/gazebo-10",
+                "/usr/include/gazebo-11",
                 "/usr/include/ignition/**",
                 "/usr/include/sdformat-6.0",
                 "/usr/include/sdformat-6.2",
+                "/usr/include/sdformat-9.1",
                 "${GENN_PATH}/include"
             ],
             "defines": [

--- a/cmake/bob_robotics.cmake
+++ b/cmake/bob_robotics.cmake
@@ -16,7 +16,7 @@ macro(BoB_project)
     include(CMakeParseArguments)
     cmake_parse_arguments(PARSED_ARGS
                           "GENN_CPU_ONLY"
-                          "EXECUTABLE;GENN_MODEL"
+                          "EXECUTABLE;GENN_MODEL;CXX_STANDARD"
                           "SOURCES;BOB_MODULES;EXTERNAL_LIBS;THIRD_PARTY;PLATFORMS;OPTIONS"
                           "${ARGV}")
     BoB_set_options()
@@ -35,6 +35,11 @@ macro(BoB_project)
         get_filename_component(NAME "${CMAKE_CURRENT_SOURCE_DIR}" NAME)
     endif()
     project(${NAME})
+
+    # Allow for setting the C++ standard on a per-project basis.
+    if(PARSED_ARGS_CXX_STANDARD AND NOT DEFINED CMAKE_CXX_STANDARD)
+        set(CMAKE_CXX_STANDARD ${PARSED_ARGS_CXX_STANDARD})
+    endif()
 
     # Include local *.h files in project. We don't strictly need to do this, but
     # if we don't then they won't be included in generated Visual Studio

--- a/cmake/bob_robotics.cmake
+++ b/cmake/bob_robotics.cmake
@@ -392,7 +392,7 @@ macro(BoB_build)
     # Conversely, only setting the compiler flag means that the surveyor example
     # mysteriously gets linker errors on Ubuntu 18.04 and my Arch Linux machine.
     #       - AD
-    if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+    if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" OR "${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
         add_compile_flags(-std=gnu++${CMAKE_CXX_STANDARD})
     endif()
 

--- a/cmake/bob_robotics.cmake
+++ b/cmake/bob_robotics.cmake
@@ -365,17 +365,31 @@ macro(BoB_build)
         set(CMAKE_EXE_LINKER_FLAGS "-Wl,--allow-multiple-definition")
     endif()
 
-    # Use C++14. On Ubuntu 16.04, seemingly setting CMAKE_CXX_STANDARD doesn't
+    # If C++ standard has not been specified explicitly either with a command
+    # line argument or with an environment variable, set the standard to C++14,
+    # the minimum supported by BoB robotics.
+    #
+    # The main reason for allowing users to choose a more recent standard is
+    # because the latest version of Gazebo (v11) requires C++17, so we need it
+    # for Gazebo-based projects.
+    if(NOT DEFINED CMAKE_CXX_STANDARD)
+        if(DEFINED ENV{BOB_ROBOTICS_CXX_STANDARD})
+            set(CMAKE_CXX_STANDARD $ENV{BOB_ROBOTICS_CXX_STANDARD})
+        else()
+            set(CMAKE_CXX_STANDARD 14)
+        endif()
+    endif()
+    set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+    # On Ubuntu 16.04, seemingly setting CMAKE_CXX_STANDARD by itself doesn't
     # work, so add the compiler flag manually.
     #
     # Conversely, only setting the compiler flag means that the surveyor example
     # mysteriously gets linker errors on Ubuntu 18.04 and my Arch Linux machine.
     #       - AD
     if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
-        add_compile_flags(-std=c++14)
+        add_compile_flags(-std=gnu++${CMAKE_CXX_STANDARD})
     endif()
-    set(CMAKE_CXX_STANDARD 14)
-    set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
     # Irritatingly, neither GCC nor Clang produce nice ANSI-coloured output if they detect
     # that output "isn't a terminal" - which seems to include whatever pipe-magick cmake includes.

--- a/examples/gazebo_display/CMakeLists.txt
+++ b/examples/gazebo_display/CMakeLists.txt
@@ -1,4 +1,5 @@
 cmake_minimum_required(VERSION 3.1)
 include(../../cmake/bob_robotics.cmake)
 BoB_project(SOURCES gazebo_display.cc
+            CXX_STANDARD 17
             BOB_MODULES video robots/gazebo)

--- a/examples/gazebo_tank/CMakeLists.txt
+++ b/examples/gazebo_tank/CMakeLists.txt
@@ -1,4 +1,5 @@
 cmake_minimum_required(VERSION 3.1)
 include(../../cmake/bob_robotics.cmake)
 BoB_project(SOURCES gazebo_tank.cc
+            CXX_STANDARD 17
             BOB_MODULES common hid robots/gazebo video)

--- a/examples/gazebo_uav/CMakeLists.txt
+++ b/examples/gazebo_uav/CMakeLists.txt
@@ -1,4 +1,5 @@
 cmake_minimum_required(VERSION 3.1)
 include(../../cmake/bob_robotics.cmake)
 BoB_project(SOURCES gazebo_uav.cc
+            CXX_STANDARD 17
             BOB_MODULES common hid robots/gazebo video)

--- a/include/robots/gazebo/uav_plugin.h
+++ b/include/robots/gazebo/uav_plugin.h
@@ -121,6 +121,6 @@ private:
     std::ofstream m_Logfile;
 
     /// \brief PID target values
-    ignition::math::v4::Pose3d m_LoiterReference;
+    ignition::math::Pose3d m_LoiterReference;
 };
 }


### PR DESCRIPTION
Closes #103.

The newest version of Gazebo requires C++17 and seeing as we were thinking of upgrading to C++17 anyway I thought now might be the time to do it. g++ v7 seems to have good support (https://gcc.gnu.org/projects/cxx-status.html) and that's the default in Ubuntu 18.04 so I think this should be relatively safe to do. Plus it would be handy to have inline variables in a few places instead of nasty macro hacks.