### PR TITLE
Provide git hash(es) of project to C++

### DIFF
--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -26,7 +26,9 @@
             "defines": [
                 "ROBOT_TYPE_TANK",
                 "ROBOT_TYPE=Tank",
-                "BOB_ROBOTICS_PATH=\"/some/path\""
+                "BOB_ROBOTICS_PATH=\"/some/path\"",
+                "BOB_PROJECT_GIT_COMMIT=\"abcdef\"",
+                "BOB_ROBOTICS_GIT_COMMIT=\"abcdef\""
             ],
             "cppStandard": "c++17",
             "intelliSenseMode": "clang-x64"

--- a/src/common/main.cc
+++ b/src/common/main.cc
@@ -117,6 +117,13 @@ main(int argc, char **argv)
     // We always want plog working
     initLogging();
 
+    /*
+     * When debugging, it's handy to know exactly which version of the source
+     * code we compiled.
+     */
+    LOGD << "Project git commit: " BOB_PROJECT_GIT_COMMIT;
+    LOGD << "BoB robotics git commit: " BOB_ROBOTICS_GIT_COMMIT;
+
 #ifndef DEBUG
     try {
 #endif // !DEBUG

--- a/src/navigation/image_database.cc
+++ b/src/navigation/image_database.cc
@@ -110,6 +110,8 @@ ImageDatabase::Recorder::Recorder(ImageDatabase &imageDatabase,
     m_YAML << "metadata"
            << "{"
            << "time" << timeStr
+           << "project_git_commit" << BOB_PROJECT_GIT_COMMIT
+           << "bob_robotics_git_commit" << BOB_ROBOTICS_GIT_COMMIT
            << "type" << (isRoute ? "route" : "grid");
 }
 


### PR DESCRIPTION
A few times now I've generated image databases with bugs in them and it's often difficult to remember which version of the code you used to generate your data files, so I thought it probably makes sense to write the git commit into the database metadata file. (It probably also makes sense to do this elsewhere for "proper" datasets when we want to be able to repeat the processing that was done reliably.)

I've added separate macros for ``BOB_ROBOTICS_GIT_COMMIT`` and ``BOB_PROJECT_GIT_COMMIT``. The latter is for when you've got a project outside of the BoB robotics tree and want to be able to get at that too.