### PR TITLE
Smarter copying of DLL files

### DIFF
--- a/bin/copy_dependencies_vcpkg.bat
+++ b/bin/copy_dependencies_vcpkg.bat
@@ -1,0 +1,17 @@
+ECHO OFF
+SETLOCAL ENABLEDELAYEDEXPANSION
+
+REM Loop through dependencies of dll/executable, filtering out lines which contain dll names
+FOR /F %%d IN ('dumpbin /dependents %1 ^| FINDSTR /I /R "[a-zA-Z_-]*\.dll"') DO (
+    REM If dll is supplied by VCPKG (others are likely to be in system32)
+    SET "VCPKG_FILE=%2\bin\%%d"
+    IF EXIST !VCPKG_FILE! (
+        REM If newer file exists in VCPKG, copy
+        XCOPY /d /q "!VCPKG_FILE!" "%~dp1" > nul
+        
+        REM recurse as dll may also have dependencies
+        CALL %~dp0copy_dependencies_vcpkg.bat "%~dp1\%%d" "%2"
+    )
+)
+
+exit 0

--- a/bin/copy_dependencies_vcpkg.bat
+++ b/bin/copy_dependencies_vcpkg.bat
@@ -2,16 +2,14 @@ ECHO OFF
 SETLOCAL ENABLEDELAYEDEXPANSION
 
 REM Loop through dependencies of dll/executable, filtering out lines which contain dll names
-FOR /F %%d IN ('dumpbin /dependents %1 ^| FINDSTR /I /R "[a-zA-Z_-]*\.dll"') DO (
+FOR /F %%d IN ('dumpbin /dependents %~1 ^| FINDSTR /I /R "[a-zA-Z_-]*\.dll"') DO (
     REM If dll is supplied by VCPKG (others are likely to be in system32)
     SET "VCPKG_FILE=%~2\bin\%%d"
     IF EXIST !VCPKG_FILE! (
         REM If newer file exists in VCPKG, copy
-        XCOPY /d /q "!VCPKG_FILE!" "%~dp1" > nul
-        
+        XCOPY /D /Q "!VCPKG_FILE!" "%~dp1" > NUL
         REM recurse as dll may also have dependencies
         CALL %~dp0copy_dependencies_vcpkg.bat "%~dp1\%%d" "%~2"
     )
 )
-
-exit 0
+ENDLOCAL

--- a/bin/copy_dependencies_vcpkg.bat
+++ b/bin/copy_dependencies_vcpkg.bat
@@ -4,13 +4,13 @@ SETLOCAL ENABLEDELAYEDEXPANSION
 REM Loop through dependencies of dll/executable, filtering out lines which contain dll names
 FOR /F %%d IN ('dumpbin /dependents %1 ^| FINDSTR /I /R "[a-zA-Z_-]*\.dll"') DO (
     REM If dll is supplied by VCPKG (others are likely to be in system32)
-    SET "VCPKG_FILE=%2\bin\%%d"
+    SET "VCPKG_FILE=%~2\bin\%%d"
     IF EXIST !VCPKG_FILE! (
         REM If newer file exists in VCPKG, copy
         XCOPY /d /q "!VCPKG_FILE!" "%~dp1" > nul
         
         REM recurse as dll may also have dependencies
-        CALL %~dp0copy_dependencies_vcpkg.bat "%~dp1\%%d" "%2"
+        CALL %~dp0copy_dependencies_vcpkg.bat "%~dp1\%%d" "%~2"
     )
 )
 

--- a/bin/copy_dependencies_vcpkg.bat
+++ b/bin/copy_dependencies_vcpkg.bat
@@ -1,8 +1,8 @@
-ECHO OFF
+@ECHO OFF
 SETLOCAL ENABLEDELAYEDEXPANSION
 
 REM Loop through dependencies of dll/executable, filtering out lines which contain dll names
-FOR /F %%d IN ('dumpbin /dependents %~1 ^| FINDSTR /I /R "[a-zA-Z_-]*\.dll"') DO (
+FOR /F %%d IN ('dumpbin /dependents "%~1" ^| FINDSTR /I /R "[a-zA-Z_-]*\.dll"') DO (
     REM If dll is supplied by VCPKG (others are likely to be in system32)
     SET "VCPKG_FILE=%~2\bin\%%d"
     IF EXIST !VCPKG_FILE! (

--- a/cmake/bob_robotics.cmake
+++ b/cmake/bob_robotics.cmake
@@ -174,17 +174,12 @@ macro(BoB_project)
     # Copy all DLLs over from vcpkg dir. We don't necessarily need all of them,
     # but it would be a hassle to figure out which ones we need.
     if(WIN32)
-        file(GLOB dll_files "${VCPKG_PACKAGE_DIR}/bin/*.dll")
-        foreach(file IN LISTS dll_files)
-            get_filename_component(filename "${file}" NAME)
-            if(NOT EXISTS "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${filename}")
-                message("Copying ${filename} to ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}...")
-                file(COPY "${file}"
-                     DESTINATION "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}")
-            endif()
+        # Add custom command to 
+        foreach(target IN LISTS BOB_TARGETS)
+            add_custom_command(TARGET ${target} POST_BUILD
+                COMMAND ${BOB_ROBOTICS_PATH}/bin/copy_dependencies_vcpkg.bat ${target} ${VCPKG_PACKAGE_DIR}
+            )
         endforeach()
-
-        link_directories("${CMAKE_RUNTIME_OUTPUT_DIRECTORY}")
     endif()
 endmacro()
 
@@ -674,12 +669,10 @@ get_filename_component(BOB_ROBOTICS_PATH .. ABSOLUTE BASE_DIR "${CMAKE_CURRENT_L
 
 # If this var is defined then this project is being included in another build
 if(NOT DEFINED BOB_DIR)
-    if(WIN32)
-        set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${BOB_ROBOTICS_PATH}/bin)
-        set(CMAKE_RUNTIME_OUTPUT_DIRECTORY_DEBUG ${BOB_ROBOTICS_PATH}/bin)
-        set(CMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE ${BOB_ROBOTICS_PATH}/bin)
-    else()
-        set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_SOURCE_DIR})
+    set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_SOURCE_DIR})
+    if(WIN32) 
+        set(CMAKE_RUNTIME_OUTPUT_DIRECTORY_DEBUG ${CMAKE_SOURCE_DIR})
+        set(CMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE ${CMAKE_SOURCE_DIR})
     endif()
 
     # Folder to build BoB modules + third-party modules

--- a/cmake/bob_robotics.cmake
+++ b/cmake/bob_robotics.cmake
@@ -177,7 +177,7 @@ macro(BoB_project)
         # Add custom command to 
         foreach(target IN LISTS BOB_TARGETS)
             add_custom_command(TARGET ${target} POST_BUILD
-                COMMAND ${BOB_ROBOTICS_PATH}/bin/copy_dependencies_vcpkg.bat ${target} ${VCPKG_PACKAGE_DIR}
+                COMMAND ${BOB_ROBOTICS_PATH}/bin/copy_dependencies_vcpkg.bat "${CMAKE_SOURCE_DIR}/${target}.exe" "${VCPKG_PACKAGE_DIR}"
             )
         endforeach()
     endif()


### PR DESCRIPTION
So there are two issues with the current strategy of building executables into the bin directory:
1. It's inconsistant with Linux and Mac
2. It breaks GeNN which deposits its dlls into the executable directory to work around the same problem

I've come up with a slightly hacky batch-file based solution which recursively calls [dumpbin](https://docs.microsoft.com/en-us/cpp/build/reference/dumpbin-reference) on the executable to find what dlls it needs and, if they're in VCPKG, copies them to the executable directory if they're newer/not present.