### PR TITLE
Fixed upside-down rendering of top-down view

### DIFF
--- a/include/antworld/route_ardin.h
+++ b/include/antworld/route_ardin.h
@@ -42,12 +42,12 @@ public:
     // Public API
     //------------------------------------------------------------------------
     void load(const std::string &filename, bool realign = true);
-    void render(meter_t antX, meter_t antY, degree_t antHeading) const;
+    void render(const Vector2<meter_t> &position, degree_t yaw, meter_t height = meter_t{0.1}) const;
 
-    bool atDestination(meter_t x, meter_t y, meter_t threshold) const;
-    std::tuple<meter_t, size_t> getDistanceToRoute(meter_t x, meter_t y) const;
+    bool atDestination(const Vector2<meter_t> &position, meter_t threshold) const;
+    std::tuple<meter_t, size_t> getDistanceToRoute(const Vector2<meter_t> &position) const;
     void setWaypointFamiliarity(size_t pos, double familiarity);
-    void addPoint(meter_t x, meter_t y, bool error);
+    void addPoint(const Vector2<meter_t> &position, bool error);
 
     const Vector2<meter_t> &getMinBound()
     {

--- a/include/antworld/route_ardin.h
+++ b/include/antworld/route_ardin.h
@@ -42,7 +42,7 @@ public:
     // Public API
     //------------------------------------------------------------------------
     void load(const std::string &filename, bool realign = true);
-    void render(const Vector2<meter_t> &position, degree_t yaw, meter_t height = meter_t{0.1}) const;
+    void render(const Pose2<meter_t, degree_t> &pose, meter_t height = meter_t{0.1}) const;
 
     bool atDestination(const Vector2<meter_t> &position, meter_t threshold) const;
     std::tuple<meter_t, size_t> getDistanceToRoute(const Vector2<meter_t> &position) const;

--- a/include/antworld/route_continuous.h
+++ b/include/antworld/route_continuous.h
@@ -36,7 +36,7 @@ public:
     // Public API
     //------------------------------------------------------------------------
     void load(const std::string &filename);
-    void render(const Vector2<meter_t> &position, degree_t antHeading, meter_t height = meter_t{0.1}) const;
+    void render(const Pose2<meter_t, degree_t> &pose, meter_t height = meter_t{0.1}) const;
 
     bool atDestination(const Vector2<meter_t> &position, meter_t threshold) const;
     std::tuple<meter_t, meter_t> getDistanceToRoute(const Vector2<meter_t> &position) const;

--- a/include/antworld/route_continuous.h
+++ b/include/antworld/route_continuous.h
@@ -36,14 +36,14 @@ public:
     // Public API
     //------------------------------------------------------------------------
     void load(const std::string &filename);
-    void render(meter_t antX, meter_t antY, degree_t antHeading) const;
+    void render(const Vector2<meter_t> &position, degree_t antHeading, meter_t height = meter_t{0.1}) const;
 
-    bool atDestination(meter_t x, meter_t y, meter_t threshold) const;
-    std::tuple<meter_t, meter_t> getDistanceToRoute(meter_t x, meter_t y) const;
+    bool atDestination(const Vector2<meter_t> &position, meter_t threshold) const;
+    std::tuple<meter_t, meter_t> getDistanceToRoute(const Vector2<meter_t> &position) const;
     Pose2<meter_t, degree_t> getPose(meter_t distance) const;
 
     void setWaypointFamiliarity(size_t pos, double familiarity);
-    void addPoint(meter_t x, meter_t y, bool error);
+    void addPoint(const Vector2<meter_t> &position, bool error);
     meter_t getLength() const{ return m_CumulativeDistance.back(); }
 
     const Vector2<meter_t> &getMinBound()

--- a/projects/ardin_mb/state_handler.cc
+++ b/projects/ardin_mb/state_handler.cc
@@ -90,7 +90,7 @@ bool StateHandler::handleEvent(State state, Event event)
         m_Renderer.renderTopDownView(m_RenderTargetTopDown, false, false);
 
         // Render route
-        m_Route.render(m_Pose, m_Pose.yaw(), m_PathHeight);
+        m_Route.render(m_Pose, m_PathHeight);
 
         // Render vector field
         m_VectorField.render(m_PathHeight);

--- a/projects/ardin_mb/state_handler.cc
+++ b/projects/ardin_mb/state_handler.cc
@@ -90,10 +90,10 @@ bool StateHandler::handleEvent(State state, Event event)
         m_Renderer.renderTopDownView(m_RenderTargetTopDown, false, false);
 
         // Render route
-        m_Route.render(m_Pose.x(), m_Pose.y(), m_Pose.yaw());
+        m_Route.render(m_Pose, m_Pose.yaw(), m_PathHeight);
 
         // Render vector field
-        m_VectorField.render();
+        m_VectorField.render(m_PathHeight);
 
         // Unbind top-down render target
         m_RenderTargetTopDown.unbind();
@@ -178,7 +178,7 @@ bool StateHandler::handleEvent(State state, Event event)
             m_Pose.yaw() -= (SimParams::scanAngle / 2.0);
 
             // Add initial replay point to route
-            m_Route.addPoint(m_Pose.x(), m_Pose.y(), false);
+            m_Route.addPoint(m_Pose, false);
 
             m_TestingScan = 0;
 
@@ -433,11 +433,11 @@ void StateHandler::resetAntPosition()
 bool StateHandler::checkAntPosition()
 {
     // If we've reached destination
-    if(m_Route.atDestination(m_Pose.x(), m_Pose.y(), SimParams::errorDistance)) {
+    if(m_Route.atDestination(m_Pose, SimParams::errorDistance)) {
         std::cerr << "Destination reached in " << m_NumTestSteps << " steps with " << m_NumTestErrors << " errors" << std::endl;
 
         // Add final point to route
-        m_Route.addPoint(m_Pose.x(), m_Pose.y(), false);
+        m_Route.addPoint(m_Pose, false);
 
         // Stop
         return false;
@@ -454,7 +454,7 @@ bool StateHandler::checkAntPosition()
         // Calculate distance to route
         meter_t distanceToRoute;
         size_t nearestRouteWaypoint;
-        std::tie(distanceToRoute, nearestRouteWaypoint) = m_Route.getDistanceToRoute(m_Pose.x(), m_Pose.y());
+        std::tie(distanceToRoute, nearestRouteWaypoint) = m_Route.getDistanceToRoute(m_Pose);
         std::cout << "\tDistance to route: " << distanceToRoute * 100.0f << "cm" << std::endl;
 
         // If we are further away than error threshold
@@ -471,7 +471,7 @@ bool StateHandler::checkAntPosition()
             m_MaxTestPoint = std::max(m_MaxTestPoint, snapWaypoint);
 
             // Add error point to route
-            m_Route.addPoint(m_Pose.x(), m_Pose.y(), true);
+            m_Route.addPoint(m_Pose, true);
 
             // Increment error counter
             m_NumTestErrors++;
@@ -479,7 +479,7 @@ bool StateHandler::checkAntPosition()
         // Otherwise, update maximum test point reached and add 'correct' point to route
         else {
             m_MaxTestPoint = std::max(m_MaxTestPoint, nearestRouteWaypoint);
-            m_Route.addPoint(m_Pose.x(), m_Pose.y(), false);
+            m_Route.addPoint(m_Pose, false);
         }
 
         return true;

--- a/projects/ardin_mb/vector_field.cc
+++ b/projects/ardin_mb/vector_field.cc
@@ -79,14 +79,14 @@ VectorField::~VectorField()
     glDeleteVertexArrays(1, &m_LinesVAO);
 }
 //------------------------------------------------------------------------
-void VectorField::render()
+void VectorField::render(meter_t height)
 {
     // Bind lines VAO
     glBindVertexArray(m_LinesVAO);
 
     // Draw lines
     glPushMatrix();
-    glTranslatef(0.0f, 0.0f, 0.1f);
+    glTranslatef(0.0f, 0.0f, static_cast<GLfloat>(height.value()));
     glDrawArrays(GL_LINES, 0, getNumPoints() * 2);
     glPopMatrix();
 

--- a/projects/ardin_mb/vector_field.h
+++ b/projects/ardin_mb/vector_field.h
@@ -15,15 +15,17 @@
 //------------------------------------------------------------------------
 class VectorField
 {
+    using degree_t = units::angle::degree_t;
+    using meter_t = units::length::meter_t;
 public:
-    VectorField(units::length::meter_t arrowLength)
+    VectorField(meter_t arrowLength)
     :   m_ArrowLength(arrowLength), m_NumX(0), m_NumY(0), m_LinesVAO(0), m_LinesPositionVBO(0)
     {
     }
 
-    VectorField(units::length::meter_t arrowLength,
-                units::length::meter_t startX, units::length::meter_t endX, units::length::meter_t gridX,
-                units::length::meter_t startY, units::length::meter_t endY, units::length::meter_t gridY)
+    VectorField(meter_t arrowLength,
+                meter_t startX, meter_t endX, meter_t gridX,
+                meter_t startY, meter_t endY, meter_t gridY)
     :   VectorField(arrowLength)
     {
         createVertices(startX, endX, gridX,
@@ -34,31 +36,31 @@ public:
     //------------------------------------------------------------------------
     // Public API
     //------------------------------------------------------------------------
-    void createVertices(units::length::meter_t startX, units::length::meter_t endX, units::length::meter_t gridX,
-                        units::length::meter_t startY, units::length::meter_t endY, units::length::meter_t gridY);
+    void createVertices(meter_t startX, meter_t endX, meter_t gridX,
+                        meter_t startY, meter_t endY, meter_t gridY);
 
     // Renders the vector field
-    void render();
+    void render(meter_t height = meter_t{0.1});
 
     // Gets number of points used to render vector field
     unsigned int getNumPoints() const{ return m_NumX * m_NumY; }
 
     // Gets the coordinates of a specific point
-    std::tuple<units::length::meter_t, units::length::meter_t> getPoint(unsigned int point) const;
+    std::tuple<meter_t, meter_t> getPoint(unsigned int point) const;
 
     // Sets novelty of a given point
-    void setNovelty(unsigned int point, const std::vector<std::pair<units::angle::degree_t, float>> &novelty);
+    void setNovelty(unsigned int point, const std::vector<std::pair<degree_t, float>> &novelty);
 
 private:
     //------------------------------------------------------------------------
     // Members
     //------------------------------------------------------------------------
-    units::length::meter_t m_StartX;
-    units::length::meter_t m_StartY;
-    units::length::meter_t m_GridX;
-    units::length::meter_t m_GridY;
+    meter_t m_StartX;
+    meter_t m_StartY;
+    meter_t m_GridX;
+    meter_t m_GridY;
 
-    const units::length::meter_t m_ArrowLength;
+    const meter_t m_ArrowLength;
 
     unsigned int m_NumX;
     unsigned int m_NumY;

--- a/src/antworld/renderer.cc
+++ b/src/antworld/renderer.cc
@@ -244,7 +244,7 @@ void Renderer::renderTopDownView(GLint viewportX, GLint viewportY, GLsizei viewp
     // Build modelview matrix so that the 'top' is up against the near clip plane
     glMatrixMode(GL_MODELVIEW);
     glLoadIdentity();
-    glTranslatef(0.0f, 0.0f, -maxBound[2].value());
+    glTranslatef(0.0f, 0.0f, -static_cast<GLfloat>(maxBound[2].value()));
 
     // Render geometry
     renderTopDownGeometry();

--- a/src/antworld/renderer.cc
+++ b/src/antworld/renderer.cc
@@ -232,18 +232,19 @@ void Renderer::renderTopDownView(GLint viewportX, GLint viewportY, GLsizei viewp
     const auto &minBound = getWorld().getMinBound();
     const auto &maxBound = getWorld().getMaxBound();
 
-    // Configure top-down orthographic projection matrix
+    // Configure top-down orthographic projection matrix to frame world in XY plane 
+    // and with the clipping planes far enough apart to contain the range in Z
     // **TODO** re-implement in Eigen
     glMatrixMode(GL_PROJECTION);
     glLoadIdentity();
     glOrtho(minBound[0].value(), maxBound[0].value(),
             minBound[1].value(), maxBound[1].value(),
-            -1.0, maxBound[2].value() - minBound[2].value());
+            0.0, maxBound[2].value() - minBound[2].value());
 
-    // Build modelview matrix to centre world
+    // Build modelview matrix so that the 'top' is up against the near clip plane
     glMatrixMode(GL_MODELVIEW);
     glLoadIdentity();
-    glScalef(1.0f, 1.0f, -1.0f);
+    glTranslatef(0.0f, 0.0f, -maxBound[2].value());
 
     // Render geometry
     renderTopDownGeometry();

--- a/src/antworld/route_ardin.cc
+++ b/src/antworld/route_ardin.cc
@@ -257,13 +257,13 @@ void RouteArdin::load(const std::string &filename, bool realign)
     glBindBuffer(GL_ARRAY_BUFFER, 0);
 }
 //----------------------------------------------------------------------------
-void RouteArdin::render(meter_t antX, meter_t antY, degree_t antHeading) const
+void RouteArdin::render(const Vector2<meter_t> &position, degree_t yaw, meter_t height) const
 {
     // Bind route VAO
     glBindVertexArray(m_WaypointsVAO);
 
     glPushMatrix();
-    glTranslatef(0.0f, 0.0f, 0.1f);
+    glTranslatef(0.0f, 0.0f, static_cast<GLfloat>(height.value()));
     glDrawArrays(GL_POINTS, 0, static_cast<GLsizei>(m_Waypoints.size()));
 
     // If there are any route points, bind
@@ -275,8 +275,8 @@ void RouteArdin::render(meter_t antX, meter_t antY, degree_t antHeading) const
 
     glBindVertexArray(m_OverlayVAO);
 
-    glTranslatef(static_cast<GLfloat>(antX.value()), static_cast<GLfloat>(antY.value()), 0.1f);
-    glRotatef(static_cast<GLfloat>(-antHeading.value()), 0.0f, 0.0f, 1.0f);
+    glTranslatef(static_cast<GLfloat>(position.x().value()), static_cast<GLfloat>(position.y().value()), 0.0f);
+    glRotatef(static_cast<GLfloat>(-yaw.value()), 0.0f, 0.0f, 1.0f);
     glDrawArrays(GL_LINES, 0, 2);
     glPopMatrix();
 
@@ -284,7 +284,7 @@ void RouteArdin::render(meter_t antX, meter_t antY, degree_t antHeading) const
     glBindVertexArray(0);
 }
 //----------------------------------------------------------------------------
-bool RouteArdin::atDestination(meter_t x, meter_t y, meter_t threshold) const
+bool RouteArdin::atDestination(const Vector2<meter_t> &position, meter_t threshold) const
 {
     // If route's empty, there is no destination so return false
     if(m_Waypoints.empty()) {
@@ -292,18 +292,18 @@ bool RouteArdin::atDestination(meter_t x, meter_t y, meter_t threshold) const
     }
     // Otherwise return true if
     else {
-        return (distance(m_Waypoints.back(), x, y) < threshold);
+        return (distance(m_Waypoints.back(), position.x(), position.y()) < threshold);
     }
 }
 //----------------------------------------------------------------------------
-std::tuple<meter_t, size_t> RouteArdin::getDistanceToRoute(meter_t x, meter_t y) const
+std::tuple<meter_t, size_t> RouteArdin::getDistanceToRoute(const Vector2<meter_t> &position) const
 {
     // Loop through segments
     meter_t minimumDistance = std::numeric_limits<meter_t>::max();
     size_t nearestWaypoint;
     for(unsigned int s = 0; s < m_Waypoints.size(); s++)
     {
-        const meter_t distanceToWaypoint = distance(m_Waypoints[s], x, y);
+        const meter_t distanceToWaypoint = distance(m_Waypoints[s], position.x(), position.y());
 
         // If this is closer than current minimum, update minimum and nearest waypoint
         if(distanceToWaypoint < minimumDistance) {
@@ -328,12 +328,12 @@ void RouteArdin::setWaypointFamiliarity(size_t pos, double familiarity)
     glBindBuffer(GL_ARRAY_BUFFER, 0);
 }
 //----------------------------------------------------------------------------
-void RouteArdin::addPoint(meter_t x, meter_t y, bool error)
+void RouteArdin::addPoint(const Vector2<meter_t> &position, bool error)
 {
     const static uint8_t errorColour[3] = {0xFF, 0, 0};
     const static uint8_t correctColour[3] = {0, 0xFF, 0};
 
-    const float position[2] = { (float)x.value(), (float)y.value() };
+    const float positionRaw[2] = { (float)position.x().value(), (float)position.y().value() };
 
     // Update this positions colour in colour buffer
     glBindBuffer(GL_ARRAY_BUFFER, m_RouteColourVBO);
@@ -343,7 +343,7 @@ void RouteArdin::addPoint(meter_t x, meter_t y, bool error)
     // Update this positions colour in colour buffer
     glBindBuffer(GL_ARRAY_BUFFER, m_RoutePositionVBO);
     glBufferSubData(GL_ARRAY_BUFFER, m_RouteNumPoints * sizeof(float) * 2,
-                    sizeof(float) * 2, position);
+                    sizeof(float) * 2, positionRaw);
     glBindBuffer(GL_ARRAY_BUFFER, 0);
     m_RouteNumPoints++;
 }

--- a/src/antworld/route_ardin.cc
+++ b/src/antworld/route_ardin.cc
@@ -257,7 +257,7 @@ void RouteArdin::load(const std::string &filename, bool realign)
     glBindBuffer(GL_ARRAY_BUFFER, 0);
 }
 //----------------------------------------------------------------------------
-void RouteArdin::render(const Vector2<meter_t> &position, degree_t yaw, meter_t height) const
+void RouteArdin::render(const Pose2<meter_t, degree_t> &pose, meter_t height) const
 {
     // Bind route VAO
     glBindVertexArray(m_WaypointsVAO);
@@ -275,8 +275,8 @@ void RouteArdin::render(const Vector2<meter_t> &position, degree_t yaw, meter_t 
 
     glBindVertexArray(m_OverlayVAO);
 
-    glTranslatef(static_cast<GLfloat>(position.x().value()), static_cast<GLfloat>(position.y().value()), 0.0f);
-    glRotatef(static_cast<GLfloat>(-yaw.value()), 0.0f, 0.0f, 1.0f);
+    glTranslatef(static_cast<GLfloat>(pose.x().value()), static_cast<GLfloat>(pose.y().value()), 0.0f);
+    glRotatef(static_cast<GLfloat>(-pose.yaw().value()), 0.0f, 0.0f, 1.0f);
     glDrawArrays(GL_LINES, 0, 2);
     glPopMatrix();
 

--- a/src/antworld/route_continuous.cc
+++ b/src/antworld/route_continuous.cc
@@ -228,7 +228,7 @@ void RouteContinuous::load(const std::string &filename)
     glBindBuffer(GL_ARRAY_BUFFER, 0);
 }
 //----------------------------------------------------------------------------
-void RouteContinuous::render(const Vector2<meter_t> &position, degree_t antHeading, meter_t height) const
+void RouteContinuous::render(const Pose2<meter_t, degree_t> &pose, meter_t height) const
 {
     // Bind route VAO
     glBindVertexArray(m_WaypointsVAO);
@@ -246,8 +246,8 @@ void RouteContinuous::render(const Vector2<meter_t> &position, degree_t antHeadi
 
     glBindVertexArray(m_OverlayVAO);
 
-    glTranslatef(static_cast<GLfloat>(position.x().value()), static_cast<GLfloat>(position.y().value()), 0.0f);
-    glRotatef(static_cast<GLfloat>(-antHeading.value()), 0.0f, 0.0f, 1.0f);
+    glTranslatef(static_cast<GLfloat>(pose.x().value()), static_cast<GLfloat>(pose.y().value()), 0.0f);
+    glRotatef(static_cast<GLfloat>(-pose.yaw().value()), 0.0f, 0.0f, 1.0f);
     glDrawArrays(GL_LINES, 0, 2);
     glPopMatrix();
 

--- a/src/antworld/route_continuous.cc
+++ b/src/antworld/route_continuous.cc
@@ -228,13 +228,13 @@ void RouteContinuous::load(const std::string &filename)
     glBindBuffer(GL_ARRAY_BUFFER, 0);
 }
 //----------------------------------------------------------------------------
-void RouteContinuous::render(meter_t antX, meter_t antY, degree_t antHeading) const
+void RouteContinuous::render(const Vector2<meter_t> &position, degree_t antHeading, meter_t height) const
 {
     // Bind route VAO
     glBindVertexArray(m_WaypointsVAO);
 
     glPushMatrix();
-    glTranslatef(0.0f, 0.0f, 0.1f);
+    glTranslatef(0.0f, 0.0f, static_cast<GLfloat>(height.value()));
     glDrawArrays(GL_POINTS, 0, static_cast<GLsizei>(m_Waypoints.size()));
 
     // If there are any route points, bind
@@ -246,7 +246,7 @@ void RouteContinuous::render(meter_t antX, meter_t antY, degree_t antHeading) co
 
     glBindVertexArray(m_OverlayVAO);
 
-    glTranslatef(static_cast<GLfloat>(antX.value()), static_cast<GLfloat>(antY.value()), 0.1f);
+    glTranslatef(static_cast<GLfloat>(position.x().value()), static_cast<GLfloat>(position.y().value()), 0.0f);
     glRotatef(static_cast<GLfloat>(-antHeading.value()), 0.0f, 0.0f, 1.0f);
     glDrawArrays(GL_LINES, 0, 2);
     glPopMatrix();
@@ -255,7 +255,7 @@ void RouteContinuous::render(meter_t antX, meter_t antY, degree_t antHeading) co
     glBindVertexArray(0);
 }
 //----------------------------------------------------------------------------
-bool RouteContinuous::atDestination(meter_t x, meter_t y, meter_t threshold) const
+bool RouteContinuous::atDestination(const Vector2<meter_t> &position, meter_t threshold) const
 {
     // If route's empty, there is no destination so return false
     if(m_Waypoints.empty()) {
@@ -263,18 +263,18 @@ bool RouteContinuous::atDestination(meter_t x, meter_t y, meter_t threshold) con
     }
     // Otherwise return true if
     else {
-        return distance(m_Waypoints.back(), x, y) < threshold;
+        return distance(m_Waypoints.back(), position.x(), position.y()) < threshold;
     }
 }
 //----------------------------------------------------------------------------
-std::tuple<meter_t, meter_t> RouteContinuous::getDistanceToRoute(meter_t x, meter_t y) const
+std::tuple<meter_t, meter_t> RouteContinuous::getDistanceToRoute(const Vector2<meter_t> &position) const
 {
     // Loop through segments
     meter_t minimumDistance = std::numeric_limits<meter_t>::max();
     size_t nearestWaypoint;
     for(unsigned int s = 0; s < m_Waypoints.size(); s++)
     {
-        const meter_t distanceToWaypoint = distance(m_Waypoints[s], x, y);
+        const meter_t distanceToWaypoint = distance(m_Waypoints[s], position.x(), position.y());
 
         // If this is closer than current minimum, update minimum and nearest waypoint
         if(distanceToWaypoint < minimumDistance) {
@@ -333,12 +333,12 @@ void RouteContinuous::setWaypointFamiliarity(size_t pos, double familiarity)
 
 }
 //----------------------------------------------------------------------------
-void RouteContinuous::addPoint(meter_t x, meter_t y, bool error)
+void RouteContinuous::addPoint(const Vector2<meter_t> &position, bool error)
 {
     constexpr static uint8_t errorColour[3] = {0xFF, 0, 0};
     constexpr static uint8_t correctColour[3] = {0, 0xFF, 0};
 
-    const float position[2] = {(float) x.value(), (float) y.value()};
+    const float positionRaw[2] = {(float)position.x().value(), (float)position.y().value()};
 
     // Check we haven't run out of buffer space
     BOB_ASSERT(m_RouteNumPoints < m_RouteMaxPoints);
@@ -351,7 +351,7 @@ void RouteContinuous::addPoint(meter_t x, meter_t y, bool error)
     // Update this vertex's position in position buffer
     glBindBuffer(GL_ARRAY_BUFFER, m_RoutePositionVBO);
     glBufferSubData(GL_ARRAY_BUFFER, m_RouteNumPoints * sizeof(float) * 2,
-                    sizeof(float) * 2, position);
+                    sizeof(float) * 2, positionRaw);
     glBindBuffer(GL_ARRAY_BUFFER, 0);
     m_RouteNumPoints++;
 }

--- a/tools/ant_world_db_creator/ant_world_map_creator.cc
+++ b/tools/ant_world_db_creator/ant_world_map_creator.cc
@@ -82,6 +82,9 @@ int bobMain(int argc, char **argv)
                                  { 0.898f, 0.718f, 0.353f });
     } else {
         renderer.getWorld().loadObj(antWorldPath / "seville_vegetation_downsampled.obj");
+
+        renderer.getWorld().setMinBound({0_m, 0_m, 0_m});
+        renderer.getWorld().setMaxBound({10_m, 10_m, 2.8_m});
     }
 
     // Create input to read snapshots from screen


### PR DESCRIPTION
I meant to fix this in #185 but totally forgot to. The basic problem was an OpenGL one but there were additional issues with correctly rendering routes and vector fields **above** the ground. This also fixes issues with the ant world map creator and takes advantage of ``Vector2<>`` and ``Pose2<>`` for various bits of route API