### PR TITLE
Image database code updates

### DIFF
--- a/include/common/macros.h
+++ b/include/common/macros.h
@@ -33,10 +33,12 @@ public:
  * objects' destructors are called and they can be stopped before they bang into
  * a wall.
  */
-#define BOB_ASSERT(EXPRESSION)                                                        \
-    if (!(EXPRESSION)) {                                                              \
-        throw BoBRobotics::AssertionFailedException(#EXPRESSION, __FILE__, __LINE__); \
-    }
+#define BOB_ASSERT(EXPRESSION)                                                            \
+    [&]() {                                                                               \
+        if (!(EXPRESSION)) {                                                              \
+            throw BoBRobotics::AssertionFailedException(#EXPRESSION, __FILE__, __LINE__); \
+        }                                                                                 \
+    }()
 
 /**!
  * \brief Defines a packed struct in MSVC or GNU-type compilers.

--- a/include/navigation/image_database.h
+++ b/include/navigation/image_database.h
@@ -241,6 +241,8 @@ private:
     static constexpr const char *EntriesFilename = "database_entries.csv";
 
     void loadMetadata();
+    bool loadCSV();
+    void readDirectoryEntries();
     void writeImage(const std::string &filename, const cv::Mat &image) const;
     void addNewEntries(std::vector<Entry> &newEntries);
     void writeEntry(std::ofstream &os, const Entry &e);

--- a/src/antworld/world.cc
+++ b/src/antworld/world.cc
@@ -314,7 +314,7 @@ void World::loadObj(const filesystem::path &filename, float scale, int maxTextur
             else if(commandString == "vt") {
                 // Read texture coordinate and check there's no unhandled components following it
                 readVector<2>(lineStream, rawTexCoords, 1.0f);
-                BOB_ASSERT(lineStream.eof())
+                BOB_ASSERT(lineStream.eof());
             }
             else if(commandString == "vn") {
                 // ignore vertex normals for now

--- a/src/navigation/image_database.cc
+++ b/src/navigation/image_database.cc
@@ -360,7 +360,7 @@ ImageDatabase::readDirectoryEntries()
         for (char &c : ext) {
             c = ::tolower(c);
         }
-        if (ext == "jpg" || ext == "png") {
+        if (ext == "jpg" || ext == "jpeg" || ext == "png") {
             // Save details to vector
             Entry entry{
                 { millimeter_t(NAN),

--- a/src/navigation/image_database.cc
+++ b/src/navigation/image_database.cc
@@ -1,7 +1,11 @@
 // BoB robotics includes
-#include "plog/Log.h"
-#include "imgproc/opencv_unwrap_360.h"
+#include "common/macros.h"
 #include "navigation/image_database.h"
+#include "imgproc/opencv_unwrap_360.h"
+
+// Third-party includes
+#include "plog/Log.h"
+#include "third_party/tinydir.h"
 
 // Standard C includes
 #include <ctime>
@@ -247,34 +251,46 @@ ImageDatabase::RouteRecorder::record(const Vector3<millimeter_t> &position,
 }
 
 ImageDatabase::ImageDatabase(const char *databasePath, bool overwrite)
-    : ImageDatabase(filesystem::path(databasePath), overwrite)
+  : ImageDatabase(filesystem::path(databasePath), overwrite)
 {}
 
 ImageDatabase::ImageDatabase(const std::string &databasePath, bool overwrite)
-    : ImageDatabase(filesystem::path(databasePath), overwrite)
+  : ImageDatabase(filesystem::path(databasePath), overwrite)
 {}
 
 ImageDatabase::ImageDatabase(const filesystem::path &databasePath, bool overwrite)
-    : m_Path(databasePath)
+  : m_Path(databasePath)
 {
     if (overwrite && databasePath.exists()) {
         LOG_WARNING << "Database already exists; overwriting";
         filesystem::remove_all(databasePath);
-    }
-
-    // If we don't have any entries, it's an empty database
-    const auto entriesPath = m_Path / EntriesFilename;
-    if (!entriesPath.exists()) {
-        // Make sure we have a directory to save into
-        filesystem::create_directory(m_Path);
+        BOB_ASSERT(filesystem::create_directory(m_Path));
         return;
     }
 
     // Try to read metadata from YAML file
     loadMetadata();
 
-    // Read in entries from CSV file
+    // Try to read entries from CSV file
+    if (!loadCSV()) {
+        // Make sure we have a directory to save into
+        filesystem::create_directory(m_Path);
+
+        LOGW << "Could not find CSV file, searching for image files in folder";
+        readDirectoryEntries();
+    }
+}
+
+bool
+ImageDatabase::loadCSV()
+{
+    // If we don't have any entries, it's an empty database
+    const auto entriesPath = m_Path / EntriesFilename;
     std::ifstream entriesFile(entriesPath.str());
+    if (!entriesFile.good()) {
+        return false;
+    }
+
     std::string line, field;
     std::vector<std::string> fields;
     std::getline(entriesFile, line); // skip first line
@@ -284,8 +300,8 @@ ImageDatabase::ImageDatabase(const filesystem::path &databasePath, bool overwrit
         while (std::getline(lineStream, field, ',')) {
             // Trim whitespace from left (not C++ at its prettiest!)
             field.erase(field.begin(), std::find_if(field.begin(), field.end(), [](int ch) {
-                return !std::isspace(ch);
-            }));
+                            return !std::isspace(ch);
+                        }));
             fields.push_back(field);
         }
         if (fields.size() < 5) {
@@ -309,14 +325,59 @@ ImageDatabase::ImageDatabase(const filesystem::path &databasePath, bool overwrit
         // Save details to vector
         Entry entry{
             { millimeter_t(std::stod(fields[0])),
-                millimeter_t(std::stod(fields[1])),
-                millimeter_t(std::stod(fields[2])) },
+              millimeter_t(std::stod(fields[1])),
+              millimeter_t(std::stod(fields[2])) },
             degree_t(std::stod(fields[3])),
             m_Path / fields[4],
             gridPosition
         };
         m_Entries.push_back(entry);
     }
+
+    return true;
+}
+
+void
+ImageDatabase::readDirectoryEntries()
+{
+    // For reading contents of directory
+    tinydir_dir dir;
+    memset(&dir, 0, sizeof(dir));
+    BOB_ASSERT(tinydir_open(&dir, m_Path.str().c_str()) == 0);
+    for (; dir.has_next; BOB_ASSERT(tinydir_next(&dir) == 0)) {
+        tinydir_file file;
+        if (tinydir_readfile(&dir, &file)) {
+            tinydir_close(&dir);
+            throw std::runtime_error("Could not read from directory");
+        }
+        if (file.is_dir) {
+            continue;
+        }
+
+        const filesystem::path fileName = file.path;
+        auto ext = fileName.extension();
+        for (char &c : ext) {
+            c = ::tolower(c);
+        }
+        if (ext == "jpg" || ext == "png") {
+            // Save details to vector
+            Entry entry{
+                { millimeter_t(NAN),
+                  millimeter_t(NAN),
+                  millimeter_t(NAN) },
+                degree_t(NAN),
+                fileName,
+                { 0, 0, 0 }
+            };
+            m_Entries.push_back(entry);
+        }
+    }
+
+    // Sort entries alphabetically by file path
+    const auto byname = [](const Entry &e1, const Entry &e2) {
+        return e1.path.str() < e2.path.str();
+    };
+    std::sort(m_Entries.begin(), m_Entries.end(), byname);
 }
 
 //! Get the path of the directory corresponding to this ImageDatabase
@@ -327,7 +388,8 @@ ImageDatabase::getPath() const
 }
 
 //! Get one Entry from the database
-const ImageDatabase::Entry &ImageDatabase::operator[](size_t i) const
+const ImageDatabase::Entry &
+ImageDatabase::operator[](size_t i) const
 {
     return m_Entries[i];
 }

--- a/src/navigation/image_database.cc
+++ b/src/navigation/image_database.cc
@@ -299,9 +299,10 @@ ImageDatabase::loadCSV()
         fields.clear();
         while (std::getline(lineStream, field, ',')) {
             // Trim whitespace from left (not C++ at its prettiest!)
-            field.erase(field.begin(), std::find_if(field.begin(), field.end(), [](int ch) {
-                            return !std::isspace(ch);
-                        }));
+            const auto notSpace = [](char c) {
+                return !std::isspace(c);
+            };
+            field.erase(field.begin(), std::find_if(field.begin(), field.end(), notSpace));
             fields.push_back(field);
         }
         if (fields.size() < 5) {

--- a/tools/image_database_browser/image_database_browser.cc
+++ b/tools/image_database_browser/image_database_browser.cc
@@ -28,7 +28,7 @@ int bobMain(int argc, char **argv)
 
     // Load images
     std::cout << "Loading images..." << std::endl;
-    const auto images = database.getImages();
+    std::vector<cv::Mat> images{ database.size() };
 
     // Iterate through images with arrow keys
     cv::namedWindow(argv[0]);
@@ -36,7 +36,10 @@ int bobMain(int argc, char **argv)
         std::stringstream ssTitle, ssNumber;
         const auto pos = database[i].position;
         ssTitle << database.getName() << " [" << i << "/" << database.size() << "]"
-           << " (" << pos[0] << ", " << pos[1] << ", " << pos[2] << ")";
+                << " (" << pos[0] << ", " << pos[1] << ", " << pos[2] << ")";
+        if (images[i].empty()) {
+            images[i] = database[i].load();
+        }
         cv::imshow(argv[0], images[i]);
         cv::setWindowTitle(argv[0], ssTitle.str());
 

--- a/tools/image_database_browser/image_database_browser.cc
+++ b/tools/image_database_browser/image_database_browser.cc
@@ -45,6 +45,13 @@ int bobMain(int argc, char **argv)
 
         size_t newi = i;
         do {
+            /*
+             * If the user presses a number key, we append this digit to a
+             * stringstream and when the user then presses 'g' we jump to that
+             * frame number. For example, if the user enters '1', '0', '0', 'g'
+             * then we jump to frame number 100 (the same way you jump to a line
+             * in vim).
+             */
             const auto key = cv::waitKeyEx(50) & OS::KeyMask;
             if (key >= '0' && key <= '9') {
                 ssNumber << static_cast<char>(key);

--- a/tools/image_database_browser/image_database_browser.cc
+++ b/tools/image_database_browser/image_database_browser.cc
@@ -77,8 +77,6 @@ int bobMain(int argc, char **argv)
                     newi = std::min(std::stoul(ssNumber.str()), database.size() - 1);
                 }
                 break;
-            default:
-                continue;
             }
 
             ssNumber.str("");


### PR DESCRIPTION
Hey!

I've made a couple of small changes to the image database code:
1.  Allow for loading a simple folder of images with ``ImageDatabase``. It just makes it easier to run simulations over image sets without any metadata (e.g. a single route recorded without positional data).
2. Let the user skip to a specific frame with ``image_database_browser`` by typing in a number and pressing g. Handy for when you're analysing image data and what to know what the world looked like at e.g. frame 100 or whatever.

I also tweaked the ``BOB_ASSERT`` macro so it's more like a proper function.

Let me know what you think :smiley: 
