### PR TITLE
PixPro USB: Set inner radius of unwrap parmas to something sensible

### DIFF
--- a/resources/panoramic_camera_parameters/pixpro_usb.yaml
+++ b/resources/panoramic_camera_parameters/pixpro_usb.yaml
@@ -2,7 +2,7 @@
 ---
 unwrapper:
     centre: [0.506944, 0.510417]
-    inner: 0
+    inner: 0.094
     outer: 0.49
     offsetDegrees: 0
     flip: 0


### PR DESCRIPTION
As pointed out by @tenxlenx, currently we're not cropping anything off the top of the image so unwrapped images look really weird at the top.

Old parameter:
![Screenshot_20201016_142720](https://user-images.githubusercontent.com/23149834/96264560-3f961200-0fbc-11eb-83e2-126642bd72b4.png)

New parameter:
![Screenshot_20201016_142813](https://user-images.githubusercontent.com/23149834/96264585-458bf300-0fbc-11eb-8750-5b7e9a31fbf2.png)
