### PR TITLE
CMake v3.5 doesn't have VERSION_GREATER_EQUAL

### DIFF
--- a/cmake/bob_robotics.cmake
+++ b/cmake/bob_robotics.cmake
@@ -527,7 +527,7 @@ macro(BoB_build)
         # hopefully we can get away without using it in this case (because we'll
         # probably only find this on Linux machines which don't care about
         # linking directories anyway)
-        if(${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.13.0")
+        if(${CMAKE_VERSION} VERSION_GREATER "3.13.0" OR ${CMAKE_VERSION} EQUAL "3.13.0")
             target_link_directories(${target} PUBLIC ${${PROJECT_NAME}_LIB_DIRS})
         endif()
     endforeach()


### PR DESCRIPTION
Addresses this problem: https://github.com/BrainsOnBoard/bob_robotics/issues/204#issuecomment-720525630

Tested with Ubuntu 16.04 docker image.