### PR TITLE
Set exception masks properly for fstreams

### DIFF
--- a/include/navigation/image_database.h
+++ b/include/navigation/image_database.h
@@ -117,8 +117,9 @@ public:
 
                 const auto path = (m_ImageDatabase.m_Path / MetadataFilename).str();
                 LOG_INFO << "Writing metadata to " << path << "...";
-                std::ofstream os(path);
-                os << m_YAML.releaseAndGetString();
+                std::ofstream ofs(path);
+                ofs.exceptions(std::ios::badbit | std::ios::failbit);
+                ofs << m_YAML.releaseAndGetString();
             }
 
             m_ImageDatabase.addNewEntries(m_NewEntries, m_ExtraFieldNames);

--- a/include/navigation/image_database.h
+++ b/include/navigation/image_database.h
@@ -475,8 +475,9 @@ private:
         }
 
         // Write image entries info to CSV file
-        std::ofstream os(path);
-        BOB_ASSERT(os.good());
+        std::ofstream os;
+        os.exceptions(std::ios::badbit | std::ios::failbit);
+        os.open(path);
         os << "X [mm], Y [mm], Z [mm], Heading [degrees], Filename";
         if (!m_IsRoute) {
             os << ", Grid X, Grid Y, Grid Z";

--- a/projects/ardin_mb/mb_memory.cc
+++ b/projects/ardin_mb/mb_memory.cc
@@ -247,6 +247,8 @@ std::tuple<unsigned int, unsigned int, unsigned int> MBMemory::present(const cv:
     m_SLM.pullStateFromDevice("EN");
 
     std::ofstream terminalStream("terminal_synaptic_state.csv");
+    terminalStream.exceptions(std::ios::badbit | std::ios::failbit);
+
     terminalStream << "Weight, Eligibility" << std::endl;
     for(unsigned int s = 0; s < m_NumKC * m_NumEN; s++) {
         terminalStream << m_GKCToEN[s] << "," << m_CKCToEN[s] * std::exp(-(t - m_TCKCToEN[s]) / 40.0) << std::endl;

--- a/projects/ardin_mb/visual_navigation_ui.cc
+++ b/projects/ardin_mb/visual_navigation_ui.cc
@@ -19,6 +19,7 @@ namespace
 void saveSpikes(const MBMemory::Spikes &spikes, const std::string &filename)
 {
     std::ofstream csvStream(filename);
+    csvStream.exceptions(std::ios::badbit | std::ios::failbit);
 
     csvStream << "Time [ms], Neuron ID" << std::endl;
 
@@ -224,6 +225,7 @@ void MBUI::saveLogs(const std::string &filename)
 
     std::cout << "Logging..." << std::endl;
     std::ofstream log(filename);
+    log.exceptions(std::ios::badbit | std::ios::failbit);
 
     log << "Num active PNs, Num active KCs" << std::endl;
     for(size_t i = 0; i < m_ActiveKCData.size(); i++) {

--- a/projects/norbot_systems_identification/angular_velocity.cc
+++ b/projects/norbot_systems_identification/angular_velocity.cc
@@ -46,6 +46,7 @@ int bobMain(int argc, char **argv)
 
     Stopwatch stopwatch;
     std::ofstream dataFile;
+    dataFile.exceptions(std::ios::badbit | std::ios::failbit);
     Vicon::UDPClient<Vicon::ObjectDataVelocity> vicon(51001); // For getting robot's position
 
     // If we're recording, ignore axis movements
@@ -69,10 +70,8 @@ int bobMain(int argc, char **argv)
             if (!stopwatch.started()) {
                 // Open a new file for writing
                 dataFile.open("data/angular_velocity.csv");
-                BOB_ASSERT(dataFile.good());
                 dataFile << "Time [ms], Yaw [rad], Pitch [rad], Roll [rad], "
-                         << "Yaw velocity [rad/s], Pitch velocity [rad/s], Roll velocity [rad/s]"
-                        ;
+                         << "Yaw velocity [rad/s], Pitch velocity [rad/s], Roll velocity [rad/s]";
 
                 // Spin robot
                 stopwatch.start();

--- a/projects/norbot_systems_identification/speed_test.cc
+++ b/projects/norbot_systems_identification/speed_test.cc
@@ -49,7 +49,8 @@ public:
         m_FilePath = dataDir / ss.str();
 
         // Open file and write header
-        m_FileStream = std::ofstream(m_FilePath.str());
+        m_FileStream.exceptions(std::ios::badbit | std::ios::failbit);
+        m_FileStream.open(m_FilePath.str());
         m_FileStream << "x, y, t\n";
         m_FileStream << std::setprecision(10); // set number of decimal places
 

--- a/projects/snapshot_bot/snapshot_bot.cc
+++ b/projects/snapshot_bot/snapshot_bot.cc
@@ -68,6 +68,8 @@ public:
         m_ImageInput(createImageInput(config)), m_Memory(createMemory(config, m_ImageInput->getOutputSize())),
         m_Robot(), m_NumSnapshots(0)
     {
+        m_LogFile.exceptions(std::ios::badbit | std::ios::failbit);
+
         // Create output directory (if necessary)
         filesystem::create_directory(m_Config.getOutputPath());
 
@@ -252,7 +254,6 @@ private:
                 }
 
                 m_LogFile.open((m_Config.getOutputPath() / "training.csv").str());
-                BOB_ASSERT(m_LogFile.good());
 
                 // Write header
                 m_LogFile << "Time [s], Filename";

--- a/projects/stone_cx/robot.cc
+++ b/projects/stone_cx/robot.cc
@@ -437,6 +437,7 @@ int bobMain(int argc, char *argv[])
 
 #ifdef RECORD_SENSORS
     std::ofstream data("data.csv");
+    data.exceptions(std::ios::badbit | std::ios::failbit);
 #endif
 
     // Run server in background,, catching any exceptions for rethrowing

--- a/projects/stone_cx/simulatorReplay.cc
+++ b/projects/stone_cx/simulatorReplay.cc
@@ -14,6 +14,7 @@
 #include <opencv2/opencv.hpp>
 
 // Common includes
+#include "common/macros.h"
 #include "plog/Log.h"
 #include "genn_utils/analogue_csv_recorder.h"
 
@@ -86,6 +87,8 @@ int bobMain(int, char **)
 #endif  // RECORD_ELECTROPHYS
 
     std::ifstream replayData("data.csv");
+    BOB_ASSERT(replayData.good());
+    replayData.exceptions(std::ios::badbit);
 
     // Simulate
     double theta = 0.0;

--- a/src/antworld/route_ardin.cc
+++ b/src/antworld/route_ardin.cc
@@ -131,9 +131,7 @@ void RouteArdin::load(const std::string &filename, bool realign)
 
     // Open file for binary IO
     std::ifstream input(filename, std::ios::binary);
-    if(!input.good()) {
-        throw std::runtime_error("Cannot open route file: " + filename);
-    }
+    input.exceptions(std::ios::badbit | std::ios::failbit);
 
     // Seek to end of file, get size and rewind
     input.seekg(0, std::ios_base::end);

--- a/src/antworld/route_continuous.cc
+++ b/src/antworld/route_continuous.cc
@@ -123,9 +123,7 @@ void RouteContinuous::load(const std::string &filename)
 {
     // Open file for binary IO
     std::ifstream input(filename, std::ios::binary);
-    if(!input.good()) {
-        throw std::runtime_error("Cannot open route file: " + filename);
-    }
+    input.exceptions(std::ios::badbit | std::ios::failbit);
 
     // Seek to end of file, get size and rewind
     input.seekg(0, std::ios_base::end);

--- a/src/antworld/world.cc
+++ b/src/antworld/world.cc
@@ -120,9 +120,7 @@ void World::load(const filesystem::path &filename, const GLfloat (&worldColour)[
 
     // Open file for binary IO
     std::ifstream input(filename.str(), std::ios::binary);
-    if(!input.good()) {
-        throw std::runtime_error("Cannot open world file:" + filename.str());
-    }
+    input.exceptions(std::ios::badbit | std::ios::failbit);
 
     // Seek to end of file, get size and rewind
     input.seekg(0, std::ios_base::end);
@@ -265,9 +263,8 @@ void World::loadObj(const filesystem::path &filename, float scale, int maxTextur
 
         // Open obj file
         std::ifstream objFile(filename.str());
-        if(!objFile.good()) {
-            throw std::runtime_error("Cannot open obj file: " + filename.str());
-        }
+        BOB_ASSERT(!objFile.fail());
+        objFile.exceptions(std::ios::badbit);
 
         // Get base path to load materials etc relative to
         const auto basePath = filename.make_absolute().parent_path();
@@ -429,9 +426,8 @@ void World::loadMaterials(const filesystem::path &basePath, const std::string &f
 {
     // Open obj file
     std::ifstream mtlFile((basePath / filename).str());
-    if(!mtlFile.good()) {
-        throw std::runtime_error("Cannot open mtl file: " + filename);
-    }
+    BOB_ASSERT(!mtlFile.fail());
+    mtlFile.exceptions(std::ios::badbit);
 
     LOG_DEBUG << "Reading material file: " << filename;
 

--- a/src/robots/gazebo/uav_plugin.cc
+++ b/src/robots/gazebo/uav_plugin.cc
@@ -270,8 +270,8 @@ GazeboQuadCopterPlugin::Load(physics::ModelPtr _model, sdf::ElementPtr _sdf)
 
     const char *logfile_location = std::getenv("LOG_FILE");
     if (logfile_location != nullptr) {
+        m_Logfile.exceptions(std::ios::badbit | std::ios::failbit);
         m_Logfile.open(logfile_location, std::ios_base::app);
-        GZ_ASSERT(m_Logfile.good(), "Log file cannot be opened.\n");
     }
     else{
         std::cerr<< "LOG_FILE not set. Flight log is disabled.\n";

--- a/tools/camera_recorder/camera_recorder.cc
+++ b/tools/camera_recorder/camera_recorder.cc
@@ -60,6 +60,7 @@ int bobMain(int, char **)
 
     // Open file to log capture data and write header
     std::ofstream data("vicon.csv");
+    data.exceptions(std::ios::badbit | std::ios::failbit);
     data << "Filename, Frame, X, Y, Z, Rx, Ry, Rz" << std::endl;
 #endif  // VICON_CAPTURE
 

--- a/tools/obj_process/obj_process.cc
+++ b/tools/obj_process/obj_process.cc
@@ -423,6 +423,7 @@ int bobMain(int argc, char **argv)
             LOGF << "Cannot open obj file: " << argv[1];
             return EXIT_FAILURE;
         }
+        inputObjFile.exceptions(std::ios::badbit);
 
         // If only one argument is passed, find bounds of model
         if(argc == 2) {
@@ -437,6 +438,7 @@ int bobMain(int argc, char **argv)
 
             // Open output file
             std::ofstream outputObjFile(outputPath.str());
+            outputObjFile.exceptions(std::ios::badbit | std::ios::failbit);
 
             // Parse bounds
             const float min[3]{ strtof(argv[2], nullptr), strtof(argv[3], nullptr), strtof(argv[4], nullptr) };


### PR DESCRIPTION
I wanted to fix up the ``ImageDatabase`` code to properly catch IO errors when we're writing databases to disk and thought I'd add the proper error checking to other places where we have ``std::fstream``s.