### PR TITLE
projects/dataset_recorder: Call sync() before program exit

### DIFF
--- a/projects/dataset_recorder/data_recorder.cc
+++ b/projects/dataset_recorder/data_recorder.cc
@@ -17,6 +17,7 @@
 #include "imgproc/opencv_unwrap_360.h"
 #include "video/panoramic.h"
 
+#include <unistd.h>
 #include <sys/stat.h>
 #include <ctime>
 
@@ -259,7 +260,8 @@ int bobMain(int argc, char* argv[])
         i++;
     }
 
-
+    // Make sure that data is actually written to disk before we exit
+    ::sync();
 
     return 0;
 


### PR DESCRIPTION
This ensures that the data is physically written to disk and not just
lurking in OS memory somewhere. Should make things a bit safer for when we
next get a random power-off.