### PR TITLE
Extra checks for experiment-grade code

### DIFF
--- a/include/navigation/image_database.h
+++ b/include/navigation/image_database.h
@@ -169,6 +169,11 @@ public:
                    << "time" << timeStr
                    << "project_git_commit" << BOB_PROJECT_GIT_COMMIT
                    << "bob_robotics_git_commit" << BOB_ROBOTICS_GIT_COMMIT
+#ifdef BOB_IS_EXPERIMENT
+                   << "is_experiment" << 1
+#else
+                   << "is_experiment" << 0
+#endif
                    << "type" << (isRoute ? "route" : "grid");
         }
 

--- a/projects/ardin_mb/CMakeLists.txt
+++ b/projects/ardin_mb/CMakeLists.txt
@@ -3,12 +3,14 @@ include(../../cmake/bob_robotics.cmake)
 
 if(NO_GENN)
     add_definitions(-DNO_GENN)
-    BoB_project(EXECUTABLE ardin_mb
+    BoB_project(IS_EXPERIMENT TRUE
+                EXECUTABLE ardin_mb
                 SOURCES ardin_mb.cc state_handler.cc opencv_texture.cc vector_field.cc visual_navigation_ui.cc
                 BOB_MODULES common antworld navigation
                 THIRD_PARTY imgui)
 else()
-    BoB_project(EXECUTABLE ardin_mb
+    BoB_project(IS_EXPERIMENT TRUE
+                EXECUTABLE ardin_mb
                 SOURCES ardin_mb.cc state_handler.cc mb_memory.cc opencv_texture.cc mb_memory_ardin.cc vector_field.cc visual_navigation_ui.cc
                 BOB_MODULES common antworld navigation
                 THIRD_PARTY imgui

--- a/projects/dataset_recorder/CMakeLists.txt
+++ b/projects/dataset_recorder/CMakeLists.txt
@@ -1,4 +1,5 @@
 cmake_minimum_required(VERSION 3.1)
 include(../../cmake/bob_robotics.cmake)
-BoB_project(SOURCES data_recorder.cc
+BoB_project(IS_EXPERIMENT TRUE
+            SOURCES data_recorder.cc
             BOB_MODULES common robots imgproc video)

--- a/projects/norbot_systems_identification/CMakeLists.txt
+++ b/projects/norbot_systems_identification/CMakeLists.txt
@@ -1,4 +1,5 @@
 cmake_minimum_required(VERSION 3.1)
 include(../../cmake/bob_robotics.cmake)
-BoB_project(SOURCES angular_velocity.cc robot.cc speed_test.cc
+BoB_project(IS_EXPERIMENT TRUE
+            SOURCES angular_velocity.cc robot.cc speed_test.cc
             BOB_MODULES common hid net robots vicon)

--- a/projects/snapshot_bot/CMakeLists.txt
+++ b/projects/snapshot_bot/CMakeLists.txt
@@ -7,11 +7,13 @@ if(NOT TARGET)
 endif()
 
 if(${TARGET} STREQUAL snapshot_bot)
-    BoB_project(EXECUTABLE snapshot_bot
+    BoB_project(IS_EXPERIMENT TRUE
+                EXECUTABLE snapshot_bot
                 SOURCES snapshot_bot.cc memory.cc image_input.cc
                 BOB_MODULES common hid imgproc navigation robots vicon video)
 else()
-    BoB_project(EXECUTABLE offline_train
+    BoB_project(IS_EXPERIMENT TRUE
+                EXECUTABLE offline_train
                 SOURCES offline_train.cc memory.cc image_input.cc
                 BOB_MODULES common imgproc navigation video)
 endif()

--- a/projects/stone_cx/CMakeLists.txt
+++ b/projects/stone_cx/CMakeLists.txt
@@ -18,7 +18,8 @@ else()
     message(FATAL_ERROR "Bad target specified")
 endif()
 
-BoB_project(EXECUTABLE ${TARGET}
+BoB_project(IS_EXPERIMENT TRUE
+            EXECUTABLE ${TARGET}
             SOURCES ${SOURCES}
             BOB_MODULES ${BOB_MODULES}
             GENN_MODEL model.cc

--- a/projects/uav_navigation/CMakeLists.txt
+++ b/projects/uav_navigation/CMakeLists.txt
@@ -1,5 +1,6 @@
 cmake_minimum_required(VERSION 3.1)
 include(../../cmake/bob_robotics.cmake)
-BoB_project(SOURCES uav_navigation.cc
+BoB_project(IS_EXPERIMENT TRUE
+            SOURCES uav_navigation.cc
             BOB_MODULES hid navigation robots/bebop
             THIRD_PARTY matplotlibcpp)

--- a/src/common/main.cc
+++ b/src/common/main.cc
@@ -104,10 +104,10 @@ initLogging()
     plog::init(severity, filename.c_str());
 
     /*
-         * Also print log messages to console in colour.
-         *
-         * The plog documentation reports that this should have static scope.
-         */
+     * Also print log messages to console in colour.
+     *
+     * The plog documentation reports that this should have static scope.
+     */
     static plog::ColorConsoleAppender<Formatter> appender;
     plog::get()->addAppender(&appender);
 }

--- a/src/common/main.cc
+++ b/src/common/main.cc
@@ -85,7 +85,7 @@ void
 initLogging()
 {
 // Get log level
-#if defined(DEBUG) || defined(_DEBUG)
+#ifdef DEBUG
     constexpr plog::Severity defaultLogLevel = plog::Severity::debug;
 #else
     constexpr plog::Severity defaultLogLevel = plog::Severity::info;

--- a/tools/ant_world_db_creator/CMakeLists.txt
+++ b/tools/ant_world_db_creator/CMakeLists.txt
@@ -1,4 +1,5 @@
 cmake_minimum_required(VERSION 3.1)
 include(../../cmake/bob_robotics.cmake)
-BoB_project(SOURCES ant_world_db_creator.cc ant_world_map_creator.cc
+BoB_project(IS_EXPERIMENT TRUE
+            SOURCES ant_world_db_creator.cc ant_world_map_creator.cc
             BOB_MODULES common antworld navigation video)


### PR DESCRIPTION
Hi! This idea was (sort of) suggested by @aphilippides a while ago and I thought it might be useful.

Essentially I've just added a few more checks to CMake for code we mark as ``IS_EXPERIMENT=TRUE``, which ideally we'd want to do for any simulation/data collection programs where the data is going to be published somewhere.

Currently the main checks are:
  * Whether there are uncommitted changes in the git working tree
  * Whether the current git commit is in the master branch

If these checks fail, you get a big red error message whenever you start your program (though otherwise it should run as normal).

This is mostly just to catch the case where e.g. you've accidentally checked out the wrong branch before you run your data collection program.