### PR TITLE
Fix OpenMP support for CMake < 3.9

### DIFF
--- a/cmake/bob_robotics.cmake
+++ b/cmake/bob_robotics.cmake
@@ -337,6 +337,16 @@ macro(always_included_packages)
             macos_find_homebrew_openmp()
         endif()
         find_package(OpenMP QUIET)
+
+        # For old versions of CMake (< 3.9) we need to manually add compiler flags instead
+        if (NOT OpenMP_CXX_FOUND)
+            if(CMAKE_CXX_COMPILER_ID STREQUAL GNU)
+                add_compile_flags(-fopenmp)
+            else()
+                # Otherwise, signal that we couldn't find it
+                set(ENABLE_OPENMP FALSE)
+            endif()
+        endif()
     endif()
     if(NOT TARGET GLEW::GLEW)
         find_package(GLEW QUIET)

--- a/cmake/external_libs/openmp.cmake
+++ b/cmake/external_libs/openmp.cmake
@@ -1,5 +1,5 @@
 if(OpenMP_CXX_FOUND)
     BoB_add_link_libraries(OpenMP::OpenMP_CXX)
-else()
+elseif (NOT ENABLE_OPENMP)
     message(WARNING "Could not find OpenMP; code will be single-threaded")
 endif()


### PR DESCRIPTION
This should fix the OpenMP issue you were having on the Jetson. I've tested in docker but I suppose we should probably test it on an actual Jetson just to be sure...