### PR TITLE
Remove units from VICON data when logging during testing

### DIFF
--- a/projects/snapshot_bot/snapshot_bot.cc
+++ b/projects/snapshot_bot/snapshot_bot.cc
@@ -394,7 +394,7 @@ private:
                     const auto &attitude = pose.attitude();
 
                     // Write extra logging data
-                    m_LogFile << ", " << objectData.getFrameNumber() << ", " << position[0] << ", " << position[1] << ", " << position[2] << ", " << attitude[0] << ", " << attitude[1] << ", " << attitude[2];
+                    m_LogFile << ", " << objectData.getFrameNumber() << ", " << position[0].value() << ", " << position[1].value() << ", " << position[2].value() << ", " << attitude[0].value() << ", " << attitude[1].value() << ", " << attitude[2].value();
                 }
 
                 // If we should save diagnostics when testing

--- a/projects/snapshot_bot/snapshot_bot.cc
+++ b/projects/snapshot_bot/snapshot_bot.cc
@@ -304,7 +304,9 @@ private:
                         const auto &attitude = pose.attitude();
 
                         // Write to CSV
-                        m_LogFile << ", " << objectData.getFrameNumber() << ", " << position[0].value() << ", " << position[1].value() << ", " << position[2].value() << ", " << attitude[0].value() << ", " << attitude[1].value() << ", " << attitude[2].value();
+                        m_LogFile << ", " << objectData.getFrameNumber() << ", ";
+                        m_LogFile << position[0].value() << ", " << position[1].value() << ", " << position[2].value() << ", ";
+                        m_LogFile << attitude[0].value() << ", " << attitude[1].value() << ", " << attitude[2].value();
                     }
                     m_LogFile << std::endl;
                 }
@@ -394,7 +396,9 @@ private:
                     const auto &attitude = pose.attitude();
 
                     // Write extra logging data
-                    m_LogFile << ", " << objectData.getFrameNumber() << ", " << position[0].value() << ", " << position[1].value() << ", " << position[2].value() << ", " << attitude[0].value() << ", " << attitude[1].value() << ", " << attitude[2].value();
+                    m_LogFile << ", " << objectData.getFrameNumber() << ", ";
+                    m_LogFile << position[0].value() << ", " << position[1].value() << ", " << position[2].value() << ", ";
+                    m_LogFile << attitude[0].value() << ", " << attitude[1].value() << ", " << attitude[2].value();
                 }
 
                 // If we should save diagnostics when testing


### PR DESCRIPTION
One of us fixed this during training but, somehow, this code path slipped through the net (cue much searching through old scripts for the right ``np.loadtxt`` magic to strip off suffixes)