### PR TITLE
Tweaks for Opteran devkit stuff

### DIFF
--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -8,6 +8,7 @@
                 "${workspaceFolder}/third_party/ev3dev-lang-cpp",
                 "${workspaceFolder}/third_party/plog/include",
                 "${workspaceFolder}/third_party/pybind11/include",
+                "${workspaceFolder}/third_party/development_kit_odk2",
                 "${ARSDK_ROOT}/out/arsdk-native/staging/usr/include",
                 "/usr/include/python3.7m",
                 "/usr/include/python3.8",

--- a/cmake/third_party/development_kit_odk2.cmake
+++ b/cmake/third_party/development_kit_odk2.cmake
@@ -1,0 +1,2 @@
+add_subdirectory("${BOB_ROBOTICS_PATH}/third_party/development_kit_odk2/devkit_driver" "${BOB_DIR}/third_party/${module}")
+BoB_add_link_libraries(devkit_driver)

--- a/include/video/odk2/odk2.h
+++ b/include/video/odk2/odk2.h
@@ -1,7 +1,9 @@
 #pragma once
 
 // Opteran DevKit includes
-#include "devkit_driver/include/devkit_driver.h"
+extern "C" {
+#include "devkit_driver/src/devkit_driver.h"
+}
 
 // BoB robotics includes
 #include "common/macros.h"

--- a/src/video/odk2/odk2.cc
+++ b/src/video/odk2/odk2.cc
@@ -18,8 +18,8 @@ ODK2::ODK2(const std::string &hostIP, const std::string &remoteIP)
 {
     // Build config
     devkitDriverConfig_t config = {};
-    strncpy(config.hostIP, hostIP.c_str(), sizeof(config.hostIP));
-    strncpy(config.remoteIP, remoteIP.c_str(), sizeof(config.remoteIP));
+    strncpy(config.hostIP, hostIP.c_str(), sizeof(config.hostIP) - 1);
+    strncpy(config.remoteIP, remoteIP.c_str(), sizeof(config.remoteIP) - 1);
     config.port = 50102;
 
     // Initialise dev-kit


### PR DESCRIPTION
I've also fixed a warning about string copying.

There were additional warnings about there being anonymous structs inside the devkit code (which are fine in C), but I guess we can just ignore those for now.