### PR TITLE
Protect BackgroundExceptionCatcher::ExceptionPtr with std::mutex

### DIFF
--- a/include/common/background_exception_catcher.h
+++ b/include/common/background_exception_catcher.h
@@ -4,6 +4,7 @@
 #include <csignal>
 
 // Standard C++ includes
+#include <mutex>
 #include <stdexcept>
 #include <unordered_set>
 #include <vector>
@@ -37,6 +38,7 @@ public:
 private:
     std::vector<int> m_Signals;
     static bool CatcherExists;
+    static std::mutex ExceptionPtrMutex;
     static std::exception_ptr ExceptionPtr;
 }; // BackgroundExceptionCatcher
 } // BoBRobotics

--- a/src/common/background_exception_catcher.cc
+++ b/src/common/background_exception_catcher.cc
@@ -42,6 +42,7 @@ signalHandler(int sig)
 
 namespace BoBRobotics {
 bool BackgroundExceptionCatcher::CatcherExists = false;
+std::mutex BackgroundExceptionCatcher::ExceptionPtrMutex;
 std::exception_ptr BackgroundExceptionCatcher::ExceptionPtr;
 
 BackgroundExceptionCatcher::BackgroundExceptionCatcher()
@@ -75,8 +76,13 @@ BackgroundExceptionCatcher::trapSignals(const std::unordered_set<int> &signals)
 void
 BackgroundExceptionCatcher::check() const
 {
-    if (ExceptionPtr) {
-        std::rethrow_exception(ExceptionPtr);
+    std::exception_ptr eptr;
+    ExceptionPtrMutex.lock();
+    eptr = ExceptionPtr;
+    ExceptionPtrMutex.unlock();
+
+    if (eptr) {
+        std::rethrow_exception(eptr);
     }
 }
 
@@ -85,7 +91,9 @@ void
 BackgroundExceptionCatcher::set(const std::exception_ptr &error)
 {
     if (CatcherExists) {
+        ExceptionPtrMutex.lock();
         ExceptionPtr = error;
+        ExceptionPtrMutex.unlock();
     } else {
         std::rethrow_exception(error);
     }


### PR DESCRIPTION
As pointed out by @neworderofjamie, std::exception_ptr is not atomic, so we need to protect it from race conditions. Figuring out how to do the correct compare/exchange magic with a std::atomic_bool turned out to be beyond me, so let's just use a mutex.