### PR TITLE
Workaround for compiler error on Visual Studio

### DIFF
--- a/include/navigation/image_database.h
+++ b/include/navigation/image_database.h
@@ -220,7 +220,10 @@ public:
                       const std::array<size_t, 3> &gridPosition,
                       Ts&&... extraFieldValues)
         {
-            BOB_ASSERT(sizeof...(extraFieldValues) == m_ExtraFieldNames.size());
+            // **NOTE** for reasons I can't quite comprehend, "BOB_ASSERT(sizeof...(extraFieldValues) == m_ExtraFieldNames.size());"
+            // results in "error C2065: 'extraFieldValues': undeclared identifier" on Visual Studio
+            constexpr size_t numExtraFields = sizeof...(extraFieldValues);
+            BOB_ASSERT(numExtraFields == m_ExtraFieldNames.size());
             BOB_ASSERT(m_Recording);
 
             Entry newEntry{


### PR DESCRIPTION
I can't quite understand why this was occurring - adding brackets doesn't help so I don't think it's some sort of horrible macro operator precedence issue. Maybe a legit compiler bug?