### PR TITLE
Mecanum is tank

### DIFF
--- a/include/robots/omni2d.h
+++ b/include/robots/omni2d.h
@@ -3,7 +3,7 @@
 // BoB robotics includes
 #include "hid/joystick.h"
 #include "net/connection.h"
-#include "robot.h"
+#include "tank.h"
 
 namespace BoBRobotics {
 namespace Robots {
@@ -11,7 +11,7 @@ namespace Robots {
 // BoBRobotics::Robots::Omni2D
 //----------------------------------------------------------------------------
 // Interface for driving Omni2D-like wheeled robots
-class Omni2D : public Robot
+class Omni2D : public Tank
 {
 public:
     //------------------------------------------------------------------------
@@ -22,28 +22,16 @@ public:
     //------------------------------------------------------------------------
     // Robot virtuals
     //------------------------------------------------------------------------
-    /**!
-     * \brief Move forward at the specified relative speed
-     *
-     * Values must be between -1 and 1 inclusive.
-     */
-    virtual void moveForward(float speed) override;
-
-    /**!
-     * \brief Stop moving forward and start turning at the specified relative speed
-     *
-     * Values must be between -1 and 1 inclusive.
-     */
-    virtual void turnOnTheSpot(float clockwiseSpeed) override;
-
-    //! Stop the robot moving
-    virtual void stopMoving() override;
-
     virtual void addJoystick(HID::Joystick &joystick, float deadZone = 0.25f) override;
     virtual void drive(const HID::Joystick &joystick, float deadZone = 0.25f) override;
     virtual void readFromNetwork(Net::Connection &connection) override;
     virtual void stopReadingFromNetwork() override;
     
+    //------------------------------------------------------------------------
+    // Tank virtuals
+    //------------------------------------------------------------------------
+    virtual void tank(float left, float right) override;
+
     //------------------------------------------------------------------------
     // Public API
     //------------------------------------------------------------------------

--- a/include/robots/omni2d.h
+++ b/include/robots/omni2d.h
@@ -26,7 +26,7 @@ public:
     virtual void drive(const HID::Joystick &joystick, float deadZone = 0.25f) override;
     virtual void readFromNetwork(Net::Connection &connection) override;
     virtual void stopReadingFromNetwork() override;
-    
+
     //------------------------------------------------------------------------
     // Tank virtuals
     //------------------------------------------------------------------------
@@ -38,10 +38,10 @@ public:
     float getForwards() const;
     float getSideways() const;
     float getTurn() const;
-    
+
 protected:
     void setWheelSpeed(float forward, float sideways, float turn);
-    
+
 private:
     float m_Forward = 0;
     float m_Sideways = 0;
@@ -49,7 +49,7 @@ private:
     Net::Connection *m_Connection = nullptr;
 
     void drive(float forward, float sideways, float turn, float deadZone);
-    void onCommandReceived(Net::Connection &, const Net::Command &command);
+    void onOmniCommandReceived(Net::Connection &, const Net::Command &command);
     bool onJoystickEvent(HID::JAxis axis, float value, float deadZone);
 }; // Omni2D
 } // Robots

--- a/include/robots/tank.h
+++ b/include/robots/tank.h
@@ -45,7 +45,7 @@ public:
     virtual void readFromNetwork(Net::Connection &connection) override;
 
     virtual void stopReadingFromNetwork() override;
-    
+
     //----------------------------------------------------------------------------
     // Declared virtuals
     //----------------------------------------------------------------------------
@@ -65,17 +65,17 @@ public:
     virtual void setMaximumSpeedProportion(float value);
 
     virtual float getMaximumSpeedProportion() const;
-    
+
     //----------------------------------------------------------------------------
     // Public API
     //----------------------------------------------------------------------------
     void controlWithThumbsticks(HID::JoystickBase<HID::JAxis, HID::JButton> &joystick);
-    
+
     void move(meters_per_second_t v,
               radians_per_second_t clockwiseSpeed,
               const bool maxScaled = false);
 
-    
+
     void tankMaxScaled(const float left, const float right, const float max = 1.f);
 
     void tank(meters_per_second_t left, meters_per_second_t right, bool maxScaled = false);
@@ -90,7 +90,7 @@ private:
 
     void drive(float x, float y, float deadZone);
 
-    void onCommandReceived(Net::Connection &, const Net::Command &command);
+    void onTankCommandReceived(Net::Connection &, const Net::Command &command);
 
     bool onJoystickEvent(HID::JAxis axis, float value, float deadZone);
 

--- a/src/robots/omni2d.cc
+++ b/src/robots/omni2d.cc
@@ -36,16 +36,22 @@ Omni2D::drive(const HID::Joystick &joystick, float deadZone)
 void
 Omni2D::readFromNetwork(Net::Connection &connection)
 {
+    // Superclass
+    Tank::readFromNetwork(connection);
+
     // handle incoming TNK commands
     connection.setCommandHandler("OMN", [this](Net::Connection &connection, const Net::Command &command) {
-        onCommandReceived(connection, command);
+        onOmniCommandReceived(connection, command);
     });
-    
+
     m_Connection = &connection;
 }
 
 void Omni2D::stopReadingFromNetwork()
 {
+    // Superclass
+    Tank::stopReadingFromNetwork();
+
     if (m_Connection) {
         // Ignore incoming TNK commands
         m_Connection->setCommandHandler("OMN", nullptr);
@@ -54,7 +60,7 @@ void Omni2D::stopReadingFromNetwork()
 
 void Omni2D::tank(float left, float right)
 {
-    std::cout << left << "," <<right << std::endl;
+    // Implement tank controls in terms of omni
     omni2D((left + right) / 2.0f, 0.0f, (left - right) / 2.0f);
 }
 
@@ -95,7 +101,7 @@ Omni2D::drive(float forward, float sideways, float turn, float deadZone)
 }
 
 void
-Omni2D::onCommandReceived(Net::Connection &, const Net::Command &command)
+Omni2D::onOmniCommandReceived(Net::Connection &, const Net::Command &command)
 {
     // second space separates left and right parameters
     if (command.size() != 4) {

--- a/src/robots/omni2d.cc
+++ b/src/robots/omni2d.cc
@@ -39,7 +39,7 @@ Omni2D::readFromNetwork(Net::Connection &connection)
     // Superclass
     Tank::readFromNetwork(connection);
 
-    // handle incoming TNK commands
+    // handle incoming OMN commands
     connection.setCommandHandler("OMN", [this](Net::Connection &connection, const Net::Command &command) {
         onOmniCommandReceived(connection, command);
     });
@@ -53,7 +53,7 @@ void Omni2D::stopReadingFromNetwork()
     Tank::stopReadingFromNetwork();
 
     if (m_Connection) {
-        // Ignore incoming TNK commands
+        // Ignore incoming OMN commands
         m_Connection->setCommandHandler("OMN", nullptr);
     }
 }

--- a/src/robots/omni2d.cc
+++ b/src/robots/omni2d.cc
@@ -14,21 +14,6 @@ Omni2D::omni2D(float forward, float sideways, float turn)
     LOGI << "Dummy motor: forward: " << forward << "; sideways: " << sideways << "; turn: " << turn;
 }
 
-void Omni2D::moveForward(float speed)
-{
-    omni2D(speed, 0.0f, 0.0f);
-}
-
-void Omni2D::turnOnTheSpot(float clockwiseSpeed)
-{
-    omni2D(0.0f, 0.0f, clockwiseSpeed);
-}
-
-void Omni2D::stopMoving()
-{
-    omni2D(0.0f, 0.0f, 0.0f);
-}
-
 void
 Omni2D::addJoystick(HID::Joystick &joystick, float deadZone)
 {
@@ -63,8 +48,14 @@ void Omni2D::stopReadingFromNetwork()
 {
     if (m_Connection) {
         // Ignore incoming TNK commands
-        m_Connection->setCommandHandler("TNK", nullptr);
+        m_Connection->setCommandHandler("OMN", nullptr);
     }
+}
+
+void Omni2D::tank(float left, float right)
+{
+    std::cout << left << "," <<right << std::endl;
+    omni2D((left + right) / 2.0f, 0.0f, (left - right) / 2.0f);
 }
 
 float

--- a/src/robots/tank.cc
+++ b/src/robots/tank.cc
@@ -84,7 +84,7 @@ void Tank::readFromNetwork(Net::Connection &connection)
     // Handle incoming TNK commands
     connection.setCommandHandler("TNK",
                                     [this](Net::Connection &connection, const Net::Command &command) {
-                                        onCommandReceived(connection, command);
+                                        onTankCommandReceived(connection, command);
                                     });
 
     connection.setCommandHandler("TNK_MAX",
@@ -238,7 +238,7 @@ void Tank::drive(float x, float y, float deadZone)
     }
 }
 
-void Tank::onCommandReceived(Net::Connection &, const Net::Command &command)
+void Tank::onTankCommandReceived(Net::Connection &, const Net::Command &command)
 {
     // second space separates left and right parameters
     if (command.size() != 3) {


### PR DESCRIPTION
This still feels slightly like an example of a bad C++ class hierarchy but I've at least tidied up the network stuff so it should work! As the primary means of selecting a robot seems to be setting ``ROBOT_TYPE``, do we _actually_ want the Robot class hierarchy to be virtual? 