### PR TITLE
GCC 5.4.0 fixes

### DIFF
--- a/include/navigation/insilico_rotater.h
+++ b/include/navigation/insilico_rotater.h
@@ -61,7 +61,7 @@ struct InSilicoRotater
             tbb::parallel_for(tbb::blocked_range<size_t>(0, numRotations()),
                 [&](const auto &r) {
                     for (size_t i = r.begin(); i != r.end(); ++i) {
-                        const auto index = toIndex(m_BeginRoll + i * m_ScanStep);
+                        const auto index = RotaterInternal<IterType>::toIndex(m_BeginRoll + i * m_ScanStep);
                         ImgProc::roll(m_Image, scratchImage, index);
                         m_Mask.roll(scratchMask, index);
 


### PR DESCRIPTION
First issue was just that the compiler was too dumb to figure out where ``toIndex`` was. Second one was much gnarlier and probably a compiler bug. It **looked** like the code to initialize thread local variables wasn't being linked correctly and I suspect that this was because the compiler was failing to figure out that the function static thread local variables were actually being used. I made them class static instead and it seemed appeased. Thread local variables still hurt my head a little but I think this is equivalent.