### PR TITLE
Add tool for converting image databases to video format

### DIFF
--- a/include/navigation/image_database.h
+++ b/include/navigation/image_database.h
@@ -448,6 +448,9 @@ public:
     //! Check if this database has any saved metadata (yet)
     bool hasMetadata() const;
 
+    //! Check if database contains a video file cf. multiple image files
+    bool isVideoType() const;
+
     template<class Func>
     void forEachImage(const Func &func, size_t frameSkip = 1,
                       bool greyscale = true) const

--- a/include/navigation/image_database.h
+++ b/include/navigation/image_database.h
@@ -82,6 +82,9 @@ class ImageDatabase
     using hertz_t = units::frequency::hertz_t;
 
 public:
+    static constexpr const char *MetadataFilename = "database_metadata.yaml";
+    static constexpr const char *EntriesFilename = "database_entries.csv";
+
     //! The metadata for an entry in an ImageDatabase
     struct Entry
     {
@@ -517,8 +520,6 @@ private:
     hertz_t m_FrameRate{ 0 };
     bool m_IsRoute;
     bool m_NeedsUnwrapping = true;
-    static constexpr const char *MetadataFilename = "database_metadata.yaml";
-    static constexpr const char *EntriesFilename = "database_entries.csv";
 
     ImageDatabase(const std::tm *creationTime, filesystem::path databasePath,
                   bool overwrite);

--- a/tools/image_database_to_video/.gitignore
+++ b/tools/image_database_to_video/.gitignore
@@ -1,0 +1,1 @@
+image_database_to_video

--- a/tools/image_database_to_video/CMakeLists.txt
+++ b/tools/image_database_to_video/CMakeLists.txt
@@ -1,0 +1,4 @@
+cmake_minimum_required(VERSION 3.1)
+include(../../cmake/bob_robotics.cmake)
+BoB_project(SOURCES image_database_to_video.cc
+            BOB_MODULES navigation)

--- a/tools/image_database_to_video/image_database_to_video.cc
+++ b/tools/image_database_to_video/image_database_to_video.cc
@@ -143,7 +143,7 @@ bobMain(int argc, char **argv)
     CLI::App app{ "Tool for converting image databases composed of separate image files to video-type databases (i.e. to save space)." };
     app.add_option("-o,--output-dir", outputDir, "Folder to save converted databases into");
     app.add_option("-d,--default-metadata", defaultMetadataPath, "Path to a default metadata file to use if one is not present");
-    app.add_option("-f", frameRate, "Frame rate at which image sequence was recorded")->required();
+    app.add_option("-r", frameRate, "Frame rate at which image sequence was recorded")->required();
 
     app.allow_extras();
     CLI11_PARSE(app, argc, argv);

--- a/tools/image_database_to_video/image_database_to_video.cc
+++ b/tools/image_database_to_video/image_database_to_video.cc
@@ -56,13 +56,20 @@ convertCSVFile(const ImageDatabase &inDatabase,
     const auto found = std::find(fields.cbegin(), fields.cend(), "Filename");
     const size_t filenameIdx = std::distance(fields.cbegin(), found);
 
+    /*
+     * Store a list of column indices excluding the one corresponding to
+     * Filename. This step is necessary because otherwise it's fiddly to work
+     * out where to write commas between fields.
+     */
     std::vector<size_t> copyIdx;
+    copyIdx.reserve(fields.size() - 1);
     for (size_t i = 0; i < fields.size() - 1; i++) {
         if (i != filenameIdx) {
             copyIdx.push_back(i);
         }
     }
 
+    // Write out new CSV file without Filename column
     std::ofstream ofs{ (outPath / ImageDatabase::EntriesFilename).str() };
     BOB_ASSERT(ofs.good());
     ofs.exceptions(std::ios::badbit);

--- a/tools/image_database_to_video/image_database_to_video.cc
+++ b/tools/image_database_to_video/image_database_to_video.cc
@@ -15,7 +15,6 @@
 #include <algorithm>
 #include <fstream>
 #include <iostream>
-#include <mutex>
 #include <string>
 
 using namespace BoBRobotics;
@@ -118,7 +117,6 @@ writeVideoFile(const ImageDatabase &inDatabase,
 {
     const auto imageSize = inDatabase[0].load(false).size();
 
-    // **TODO**: Set FPS correctly
     cv::VideoWriter writer{ videoFile.str(),
                             cv::VideoWriter::fourcc(VideoFormat[0], VideoFormat[1], VideoFormat[2], VideoFormat[3]),
                             frameRate,
@@ -137,7 +135,6 @@ bobMain(int argc, char **argv)
     double frameRate;
 
     CLI::App app{ "Tool for converting image databases composed of separate image files to video-type databases (i.e. to save space)." };
-    // **TODO**: Add option to delete converted databases
     app.add_option("-o,--output-dir", outputDir, "Folder to save converted databases into");
     app.add_option("-f", frameRate, "Frame rate at which image sequence was recorded")->required();
 
@@ -152,7 +149,6 @@ bobMain(int argc, char **argv)
         BOB_ASSERT(filesystem::create_directory(outputDir));
     }
 
-    std::mutex printMtx;
     const auto convertDatabase = [&](const auto &databasePath) {
         const ImageDatabase inDatabase{ databasePath };
         BOB_ASSERT(!inDatabase.isVideoType());
@@ -161,9 +157,7 @@ bobMain(int argc, char **argv)
         const auto outPath = outputDir / inDatabase.getName();
         // **TODO**: Allow for optionally overwriting converted databases
         BOB_ASSERT(!outPath.exists());
-        printMtx.lock();
-        std::cout << "Saving new database to " << outPath << "...\n";
-        printMtx.unlock();
+        LOGI << "Saving new database to " << outPath;
         filesystem::create_directory(outPath);
 
         const auto videoFile = outPath / (inDatabase.getName() + VideoExtension);

--- a/tools/image_database_to_video/image_database_to_video.cc
+++ b/tools/image_database_to_video/image_database_to_video.cc
@@ -1,0 +1,83 @@
+// BoB robotics includes
+#include "common/macros.h"
+#include "common/path.h"
+#include "navigation/image_database.h"
+
+// TBB
+#include "tbb/parallel_for_each.h"
+
+// Third-party includes
+#include "third_party/CLI11.hpp"
+#include "third_party/path.h"
+
+// Standard C++ includes
+#include <iostream>
+#include <mutex>
+#include <string>
+
+using namespace BoBRobotics;
+
+// **TODO**: Allow user to choose output video format
+constexpr const char *VideoExtension = ".mp4";
+constexpr const char *VideoFormat = "mp4v";
+
+void
+writeVideoFile(const Navigation::ImageDatabase &inDatabase,
+               const filesystem::path &outPath)
+{
+    const auto imageSize = inDatabase[0].load(false).size();
+
+    // **TODO**: Set FPS correctly
+    const auto videoPath = outPath / (inDatabase.getName() + VideoExtension);
+    cv::VideoWriter writer{ videoPath.str(),
+                            cv::VideoWriter::fourcc(VideoFormat[0], VideoFormat[1], VideoFormat[2], VideoFormat[3]),
+                            30.0, /*fps*/
+                            imageSize };
+    BOB_ASSERT(writer.isOpened());
+
+    for (const auto &entry : inDatabase) {
+        writer.write(entry.load(/*greyscale=*/false));
+    }
+}
+
+int
+bobMain(int argc, char **argv)
+{
+    filesystem::path outputDir = "video_databases";
+
+    CLI::App app{ "Tool for converting image databases composed of separate image files to video-type databases (i.e. to save space)." };
+    // **TODO**: Add option to delete converted databases
+    app.add_option("-o,--output-dir", outputDir, "Folder to save converted databases into");
+    app.allow_extras();
+    CLI11_PARSE(app, argc, argv);
+    if (app.remaining_size() == 0) {
+        std::cout << app.help();
+        return EXIT_FAILURE;
+    }
+
+    if (!outputDir.exists()) {
+        BOB_ASSERT(filesystem::create_directory(outputDir));
+    }
+
+    std::mutex printMtx;
+    const auto convertDatabase = [&](const auto &databasePath) {
+        const Navigation::ImageDatabase inDatabase{ databasePath };
+        BOB_ASSERT(!inDatabase.isVideoType());
+        BOB_ASSERT(!inDatabase.empty());
+
+        const auto outPath = outputDir / inDatabase.getName();
+        // **TODO**: Allow for optionally overwriting converted databases
+        BOB_ASSERT(!outPath.exists());
+        printMtx.lock();
+        std::cout << "Saving new database to " << outPath << "...\n";
+        printMtx.unlock();
+        filesystem::create_directory(outPath);
+
+        writeVideoFile(inDatabase, outPath);
+    };
+
+    // Convert databases in parallel
+    tbb::parallel_for_each(app.remaining(), convertDatabase);
+
+    return EXIT_SUCCESS;
+}


### PR DESCRIPTION
@tenxlenx currently has a huge number of image databases saved as sequences of images (hundreds of GBs). For the sake of being able to upload them without eating all our Git LFS allowance.

@tenxlenx: I figured rather than uploading the converted databases myself it'd be better to share the tool with you so that you can convert them yourself once you've trimmed all the junk frames etc. (But let's wait until we've merged this PR before running it over the databases.)