### PR TITLE
Don't use GAZEBO_CXX_FLAGS

### DIFF
--- a/cmake/external_libs/gazebo.cmake
+++ b/cmake/external_libs/gazebo.cmake
@@ -1,4 +1,3 @@
 BoB_add_include_directories(${GAZEBO_INCLUDE_DIRS})
 BoB_add_link_libraries(${GAZEBO_LIBRARIES})
 BoB_add_link_directories(${GAZEBO_LIBRARY_DIRS})
-add_compile_flags(${GAZEBO_CXX_FLAGS})


### PR DESCRIPTION
It seems like the only thing it does is force the C++ standard to C++11,
which we don't want.