### PR TITLE
Fix builds using OpenCV 4.3+ on CMake <= 3.10

### DIFF
--- a/cmake/external_libs/opencv.cmake
+++ b/cmake/external_libs/opencv.cmake
@@ -13,6 +13,12 @@
 #
 # We also provide an extra option to explicitly use pkg-config.
 if(NOT OpenCV_FOUND)
+    # The CMake package file for OpenCV v4.3+ appears to have a bug in which
+    # means that the C++ standard is forced to C++11, which will break BoB
+    # robotics code as we use C++14 features all over the place. Setting this
+    # variable seems to be a good workaround.
+    set(OPENCV_COMPILE_FEATURES "")
+
     if(NOT FIND_OPENCV_WITH_PKGCONFIG)
         find_package(OpenCV QUIET)
     endif()


### PR DESCRIPTION
Fixes #265.

Without this, the C++ standard is forced to C++11 on CMake <= v3.10, which causes build errors for BoB robotics code.