### PR TITLE
Fix image path in examples/perfect_memory

### DIFF
--- a/examples/perfect_memory/perfect_memory.cc
+++ b/examples/perfect_memory/perfect_memory.cc
@@ -1,4 +1,5 @@
 // BoB robotics includes
+#include "common/macros.h"
 #include "common/path.h"
 #include "common/timer.h"
 #include "navigation/image_database.h"
@@ -148,7 +149,8 @@ int bobMain(int, char **)
         Timer<> t{ "Time taken for testing: " };
 
         // Treat snapshot #10 as test data
-        cv::Mat snap = cv::imread((Path::getRepoPath() / "tools/ant_world_db_creator/ant1_route1/image00010.png").str(), cv::IMREAD_GRAYSCALE);
+        cv::Mat snap = cv::imread((Path::getRepoPath() / "tools/ant_world_db_creator/ant1_route1/image_00010.png").str(), cv::IMREAD_GRAYSCALE);
+        BOB_ASSERT(!snap.empty());
         cv::resize(snap, snap, imSize);
         size_t snapshot;
         float difference;


### PR DESCRIPTION
Commit 530e873b changed the code to use ``Path::getRepoPath()`` to get to the root of the BoB robotics repo, but in doing so accidentally changed the name of the file, breaking the HOG example.