### PR TITLE
CMake: Re-add OpenMP support when building with Eigen

### DIFF
--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.10)
 include(../../cmake/BoBRobotics.cmake)
-project(common)
+project(bob_common)
 
 set(SOURCES background_exception_catcher.cc geometry.cc macros.cc main.cc
     map_coordinate.cc path.cc pid.cc semaphore.cc serial_interface.cc
@@ -19,23 +19,29 @@ if(I2C_FOUND)
          lm9ds1_imu.cc pca_9685.cc)
 endif()
 
-add_library(common STATIC ${SOURCES})
-add_library(BoBRobotics::common ALIAS common)
+add_library(bob_common STATIC ${SOURCES})
+add_library(BoBRobotics::common ALIAS bob_common)
 
 find_package(BoBThirdParty REQUIRED COMPONENTS plog)
 find_package(Eigen3 REQUIRED)
 find_package(Threads REQUIRED)
-target_link_libraries(common PUBLIC BoBRobotics::base
+target_link_libraries(bob_common PUBLIC BoBRobotics::base
                       BoBThirdParty::plog Eigen3::Eigen Threads::Threads
                       ${I2C_LIBRARIES})
 
+find_package(OpenMP)
+if(OpenMP_CXX_FOUND)
+    target_link_libraries(bob_common PUBLIC OpenMP::OpenMP_CXX)
+endif()
+
+
 # Default include path
-target_include_directories(common PUBLIC "${BOB_ROBOTICS_PATH}/include")
+target_include_directories(bob_common PUBLIC "${BOB_ROBOTICS_PATH}/include")
 
 include(BoBGetGitCommits)
 get_git_commits()
 
-target_compile_definitions(common PUBLIC
+target_compile_definitions(bob_common PUBLIC
                            -DBOB_ROBOTICS_PATH="${BOB_ROBOTICS_PATH}"
 
                            # Disable some units types for faster compilation
@@ -62,6 +68,6 @@ target_compile_definitions(common PUBLIC
 if(EXISTS /sys/module/tegra_fuse/parameters/tegra_chip_id)
     file(READ /sys/module/tegra_fuse/parameters/tegra_chip_id TEGRA_CHIP_ID)
     string(STRIP ${TEGRA_CHIP_ID} TEGRA_CHIP_ID)
-    target_compile_definitions(common PUBLIC -DTEGRA_CHIP_ID=${TEGRA_CHIP_ID})
+    target_compile_definitions(bob_common PUBLIC -DTEGRA_CHIP_ID=${TEGRA_CHIP_ID})
     message(STATUS "Tegra chip id: ${TEGRA_CHIP_ID}")
 endif()

--- a/src/navigation/CMakeLists.txt
+++ b/src/navigation/CMakeLists.txt
@@ -12,3 +12,8 @@ target_include_directories(${BOB_MODULE_TARGET} PUBLIC ${OpenCV_INCLUDE_DIRS}
                            ${TBB_INCLUDE_DIRS})
 target_link_libraries(${BOB_MODULE_TARGET} PUBLIC Eigen3::Eigen ${OpenCV_LIBS}
                       ${TBB_LIBRARIES})
+
+find_package(OpenMP)
+if(OpenMP_CXX_FOUND)
+    target_link_libraries(${BOB_MODULE_TARGET} PUBLIC OpenMP::OpenMP_CXX)
+endif()

--- a/src/robots/control/CMakeLists.txt
+++ b/src/robots/control/CMakeLists.txt
@@ -9,3 +9,8 @@ find_package(Eigen3 REQUIRED)
 find_package(OpenCV REQUIRED)
 target_include_directories(${BOB_MODULE_TARGET} PUBLIC ${OpenCV_INCLUDE_DIRS})
 target_link_libraries(${BOB_MODULE_TARGET} PUBLIC Eigen3::Eigen ${OpenCV_LIBS})
+
+find_package(OpenMP)
+if(OpenMP_CXX_FOUND)
+    target_link_libraries(${BOB_MODULE_TARGET} PUBLIC OpenMP::OpenMP_CXX)
+endif()

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -13,3 +13,8 @@ add_executable(tests circstat.cc dct.cc differencers.cc geometry.cc
 target_include_directories(tests PUBLIC ${GTEST_INCLUDE_DIRS})
 target_link_libraries(tests PUBLIC ${BoBRobotics_LIBRARIES}
                       ${BoBThirdParty_LIBRARIES} Eigen3::Eigen)
+
+find_package(OpenMP)
+if(OpenMP_CXX_FOUND)
+    target_link_libraries(tests PUBLIC OpenMP::OpenMP_CXX)
+endif()


### PR DESCRIPTION
After the big CMake tidy-up, I accidentally removed this, meaning that Eigen was only running single threaded.