### PR TITLE
CMake: Don't use newfangled Eigen3::Eigen target

### DIFF
--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -26,11 +26,12 @@ find_package(BoBThirdParty REQUIRED COMPONENTS plog)
 find_package(Eigen3 REQUIRED)
 find_package(Threads REQUIRED)
 target_link_libraries(common PUBLIC BoBRobotics::base
-                      BoBThirdParty::plog Eigen3::Eigen Threads::Threads
+                      BoBThirdParty::plog Threads::Threads
                       ${I2C_LIBRARIES})
 
 # Default include path
-target_include_directories(common PUBLIC "${BOB_ROBOTICS_PATH}/include")
+target_include_directories(common PUBLIC "${BOB_ROBOTICS_PATH}/include"
+                           ${EIGEN3_INCLUDE_DIRS})
 
 include(BoBGetGitCommits)
 get_git_commits()

--- a/src/navigation/CMakeLists.txt
+++ b/src/navigation/CMakeLists.txt
@@ -9,6 +9,6 @@ find_package(Eigen3 REQUIRED)
 find_package(OpenCV REQUIRED)
 find_package(TBB REQUIRED)
 target_include_directories(${BOB_MODULE_TARGET} PUBLIC ${OpenCV_INCLUDE_DIRS}
-                           ${TBB_INCLUDE_DIRS})
-target_link_libraries(${BOB_MODULE_TARGET} PUBLIC Eigen3::Eigen ${OpenCV_LIBS}
+                           ${TBB_INCLUDE_DIRS} ${EIGEN3_INCLUDE_DIRS})
+target_link_libraries(${BOB_MODULE_TARGET} PUBLIC ${OpenCV_LIBS}
                       ${TBB_LIBRARIES})

--- a/src/robots/control/CMakeLists.txt
+++ b/src/robots/control/CMakeLists.txt
@@ -7,5 +7,6 @@ BoB_module(collision_detector.cc pure_pursuit_controller.cc)
 
 find_package(Eigen3 REQUIRED)
 find_package(OpenCV REQUIRED)
-target_include_directories(${BOB_MODULE_TARGET} PUBLIC ${OpenCV_INCLUDE_DIRS})
-target_link_libraries(${BOB_MODULE_TARGET} PUBLIC Eigen3::Eigen ${OpenCV_LIBS})
+target_include_directories(${BOB_MODULE_TARGET} PUBLIC ${EIGEN3_INCLUDE_DIRS}
+                           ${OpenCV_INCLUDE_DIRS})
+target_link_libraries(${BOB_MODULE_TARGET} PUBLIC ${OpenCV_LIBS})

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -10,6 +10,6 @@ add_executable(tests circstat.cc dct.cc differencers.cc geometry.cc
                gps_reader.cc image_database.cc infomax.cc mask.cc
                nmea_parser.cc opencv_unwrap_360_serialisation.cc
                perfect_memory.cc string.cc tests.cc)
-target_include_directories(tests PUBLIC ${GTEST_INCLUDE_DIRS})
+target_include_directories(tests PUBLIC ${EIGEN3_INCLUDE_DIRS} ${GTEST_INCLUDE_DIRS})
 target_link_libraries(tests PUBLIC ${BoBRobotics_LIBRARIES}
-                      ${BoBThirdParty_LIBRARIES} Eigen3::Eigen)
+                      ${BoBThirdParty_LIBRARIES})


### PR DESCRIPTION
BoB robotics code is currently not building on Ubuntu 16.04 because of an Eigen-related issue. It turns out that the version of Eigen included with Ubuntu 16.04 doesn't create it. Just use the EIGEN3_INCLUDE_DIRS variable instead, which seems to work with both old and new versions of Eigen.

Let me know if this fixes things for you @neworderofjamie !