### PR TITLE
Fix clang-tidy warnings

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -116,33 +116,33 @@ for(b = 0; b < builderNodes.size(); b++) {
             }
 
             // Only run on nodes which actually have clang-tidy installed
-//             if(nodeLabel.contains("clang_tidy")) {
-//                 stage("Running clang-tidy (" + env.NODE_NAME + ")") {
-//                     // Generate unique name for message
-//                     def uniqueMsg = "msg_clang_tidy_" + env.NODE_NAME;
-//                     def runClangTidyStatus = sh script:"./bin/run_clang_tidy_check --generate-fixes 1> \"" + uniqueMsg + "\" 2> \"" + uniqueMsg + "\""
+            if(nodeLabel.contains("clang_tidy")) {
+                stage("Running clang-tidy (" + env.NODE_NAME + ")") {
+                    // Generate unique name for message
+                    def uniqueMsg = "msg_clang_tidy_" + env.NODE_NAME;
+                    def runClangTidyStatus = sh script:"./bin/run_clang_tidy_check --generate-fixes 1> \"" + uniqueMsg + "\" 2> \"" + uniqueMsg + "\""
 
-//                     archive uniqueMsg;
+                    archive uniqueMsg;
 
-//                     recordIssues enabledForFailure: true, tool: clangTidy(pattern: "**/msg_clang_tidy_" + env.NODE_NAME, id: "clang_tidy_" + env.NODE_NAME), qualityGates: [[threshold: 1, type: 'TOTAL', unstable: true]]
-//                     if(runClangTidyStatus != 0) {
-//                         setBuildStatus("Running clang-tidy (" + env.NODE_NAME + ")", "FAILURE")
-//                     }
+                    recordIssues enabledForFailure: true, tool: clangTidy(pattern: "**/msg_clang_tidy_" + env.NODE_NAME, id: "clang_tidy_" + env.NODE_NAME), qualityGates: [[threshold: 1, type: 'TOTAL', unstable: true]]
+                    if(runClangTidyStatus != 0) {
+                        setBuildStatus("Running clang-tidy (" + env.NODE_NAME + ")", "FAILURE")
+                    }
 
-//                     // If there are auto-generated fixes, archive these in a zip file
-//                     def hasFixes = fileExists "./clang_tidy_fixes"
-//                     if(hasFixes) {
-//                         // **YUCK**: clang-tidy's fixes use absolute paths
-//                         sh "sed -i 's|" + env.WORKSPACE + "|.|g' ./clang_tidy_fixes/*"
+                    // If there are auto-generated fixes, archive these in a zip file
+                    def hasFixes = fileExists "./clang_tidy_fixes"
+                    if(hasFixes) {
+                        // **YUCK**: clang-tidy's fixes use absolute paths
+                        sh "sed -i 's|" + env.WORKSPACE + "|.|g' ./clang_tidy_fixes/*"
 
-//                         def fileName = "clang_tidy_fixes_" + env.NODE_NAME + ".zip";
-//                         echo "Archiving clang-tidy fixes as " + fileName;
-//                         zip zipFile: fileName, archive: true, dir: './clang_tidy_fixes'
-//                     } else {
-//                         echo "No clang-tidy fixes found to archive"
-//                     }
-//                 }
-//             }
+                        def fileName = "clang_tidy_fixes_" + env.NODE_NAME + ".zip";
+                        echo "Archiving clang-tidy fixes as " + fileName;
+                        zip zipFile: fileName, archive: true, dir: './clang_tidy_fixes'
+                    } else {
+                        echo "No clang-tidy fixes found to archive"
+                    }
+                }
+            }
         }
     }
 }

--- a/examples/see3cam/see3cam.cc
+++ b/examples/see3cam/see3cam.cc
@@ -87,7 +87,7 @@ int bobMain(int argc, char *argv[])
     cv::namedWindow("Unwrapped", cv::WINDOW_NORMAL);
     cv::resizeWindow("Unwrapped", unwrapWidth, unwrapHeight);
 
-    cv::Mat output(rawHeight, rawWidth, CV_8UC1);
+    cv::Mat image(rawHeight, rawWidth, CV_8UC1);
     cv::Mat unwrapped(unwrapHeight, unwrapWidth, CV_8UC1);
 
     {
@@ -98,24 +98,24 @@ int bobMain(int argc, char *argv[])
             try {
                 switch (mode) {
                 case Mode::Clamp:
-                    cam.captureSuperPixelClamp(output);
+                    cam.captureSuperPixelClamp(image);
                     break;
                 case Mode::Shift:
-                    cam.captureSuperPixel(output);
+                    cam.captureSuperPixel(image);
                     break;
                 case Mode::WhiteBalanceU30:
-                    cam.captureSuperPixelWBU30(output);
+                    cam.captureSuperPixelWBU30(image);
                     break;
                 case Mode::WhiteBalanceCoolWhite:
-                    cam.captureSuperPixelWBCoolWhite(output);
+                    cam.captureSuperPixelWBCoolWhite(image);
                     break;
                 case Mode::Greyscale:
-                    cam.captureSuperPixelGreyscale(output);
+                    cam.captureSuperPixelGreyscale(image);
                 }
 
-                cv::imshow("Raw", output);
+                cv::imshow("Raw", image);
 
-                unwrapper.unwrap(output, unwrapped);
+                unwrapper.unwrap(image, unwrapped);
                 cv::imshow("Unwrapped", unwrapped);
             } catch (Video::Video4LinuxCamera::Error const &) {
                 // Ignore V4L errors
@@ -123,23 +123,23 @@ int bobMain(int argc, char *argv[])
 
             const int key = cv::waitKey(1);
             if(key == '1') {
-                setMode(Mode::Clamp, mode, output, unwrapped);
+                setMode(Mode::Clamp, mode, image, unwrapped);
                 LOG_INFO << "Clamp mode";
             }
             else if(key == '2') {
-                setMode(Mode::Shift, mode, output, unwrapped);
+                setMode(Mode::Shift, mode, image, unwrapped);
                 LOG_INFO << "Scale mode";
             }
             else if(key == '3') {
-                setMode(Mode::WhiteBalanceCoolWhite, mode, output, unwrapped);
+                setMode(Mode::WhiteBalanceCoolWhite, mode, image, unwrapped);
                 LOG_INFO << "White balance (cool white)";
             }
             else if(key == '4') {
-                setMode(Mode::WhiteBalanceU30, mode, output, unwrapped);
+                setMode(Mode::WhiteBalanceU30, mode, image, unwrapped);
                 LOG_INFO << "White balance (U30)";
             }
             else if(key == '5') {
-                setMode(Mode::Greyscale, mode, output, unwrapped);
+                setMode(Mode::Greyscale, mode, image, unwrapped);
                 LOG_INFO << "Greyscale";
             }
             else if(key == 'c') {

--- a/include/navigation/image_database.h
+++ b/include/navigation/image_database.h
@@ -121,7 +121,7 @@ public:
     class VideoFileWriter
       : public FrameWriter {
     public:
-        VideoFileWriter(const ImageDatabase &, std::string extension, std::string codec);
+        VideoFileWriter(const ImageDatabase &, const std::string& extension, std::string codec);
         void writeFrame(const cv::Mat &frame, Entry &entry, const std::function<std::string()> &getFileName) override;
         const std::string &getVideoFileName() const;
 

--- a/include/navigation/image_database.h
+++ b/include/navigation/image_database.h
@@ -103,6 +103,7 @@ public:
 
     class FrameWriter {
     public:
+        virtual ~FrameWriter() = default;
         virtual void writeFrame(const cv::Mat &frame, Entry &entry,
                                 const std::function<std::string()> &getFileName) = 0;
     };

--- a/projects/snapshot_bot/image_input.cc
+++ b/projects/snapshot_bot/image_input.cc
@@ -149,7 +149,7 @@ cv::Mat ImageInputBinary::readSegmentIndices(const cv::Mat &snapshot)
 
     // For some reason watershed thresholding results in a border around image so return ROI inside this
     // **NOTE** we don't use getOutputSize() here as it may be overriden in derived classes
-    return cv::Mat(m_SegmentIndices, cv::Rect(1, 1, getUnwrapSize().width - 2, getUnwrapSize().height - 2));
+    return { m_SegmentIndices, cv::Rect(1, 1, getUnwrapSize().width - 2, getUnwrapSize().height - 2) };
 }
 
 //----------------------------------------------------------------------------

--- a/projects/snapshot_bot/memory.cc
+++ b/projects/snapshot_bot/memory.cc
@@ -295,9 +295,9 @@ InfoMax::InfoMaxType InfoMax::createInfoMax(const Config &config, const cv::Size
         LOGI << "\tLoading weights from " << weightPath;
 
         const auto weights = readMatrix<InfoMaxWeightMatrixType::Scalar>(weightPath);
-        return InfoMaxType(inputSize, weights);
+        return { inputSize, weights };
     } else {
-        return InfoMaxType(inputSize);
+        return { inputSize };
     }
 }
 

--- a/projects/snapshot_bot/memory.cc
+++ b/projects/snapshot_bot/memory.cc
@@ -80,7 +80,7 @@ void MemoryBase::trainRoute(const Navigation::ImageDatabase &route,
                     snapshots[i] = imageInput.processSnapshot(snapshot);
                     loadProgBar.increment();
                 },
-                /*testFrameSkip=*/testFrameSkip,
+                /*frameSkip=*/testFrameSkip,
                 /*greyscale=*/false);
     }
 

--- a/projects/stone_cx/robot.cc
+++ b/projects/stone_cx/robot.cc
@@ -54,6 +54,7 @@ namespace
 class HeadingSource
 {
 public:
+    virtual ~HeadingSource() = default;
     virtual radian_t getHeading() = 0;
 };
 

--- a/python/antworld/antworld.cc
+++ b/python/antworld/antworld.cc
@@ -227,7 +227,6 @@ static PyMethodDef Agent_methods[] = {
     // clang-format on
 };
 
-// NOLINTNEXTLINE
 static PyTypeObject AgentType = {
     // clang-format off
     PyVarObject_HEAD_INIT(&PyType_Type, 0)
@@ -269,6 +268,7 @@ static PyTypeObject AgentType = {
     nullptr,                    /* tp_init */
     nullptr,                    /* tp_alloc */
     (newfunc) Agent_new,        /* tp_new */
+    // NOLINTNEXTLINE
 };
 
 static struct PyModuleDef ModuleDefinitions
@@ -279,6 +279,7 @@ static struct PyModuleDef ModuleDefinitions
     "A Python wrapper for the BoB robotics ant world module",
     -1,
     // clang-format on
+    // NOLINTNEXTLINE
 };
 
 PyMODINIT_FUNC

--- a/python/antworld/antworld.cc
+++ b/python/antworld/antworld.cc
@@ -227,6 +227,7 @@ static PyMethodDef Agent_methods[] = {
     // clang-format on
 };
 
+// NOLINTNEXTLINE
 static PyTypeObject AgentType = {
     // clang-format off
     PyVarObject_HEAD_INIT(&PyType_Type, 0)
@@ -281,7 +282,7 @@ static struct PyModuleDef ModuleDefinitions
 };
 
 PyMODINIT_FUNC
-PyInit__antworld(void)
+PyInit__antworld(void) // NOLINT
 {
     import_array();             // init numpy
     BoBRobotics::initLogging(); // init plog

--- a/src/common/main.cc
+++ b/src/common/main.cc
@@ -16,7 +16,7 @@ struct Formatter
 {
     static plog::util::nstring header()
     {
-        return plog::util::nstring();
+        return {};
     }
 
     static plog::util::nstring format(const plog::Record &record)

--- a/src/navigation/image_database.cc
+++ b/src/navigation/image_database.cc
@@ -81,7 +81,7 @@ ImageDatabase::ImageFileWriter::writeFrame(const cv::Mat &frame, Entry &entry,
 }
 
 ImageDatabase::VideoFileWriter::VideoFileWriter(const ImageDatabase &database,
-                                                std::string extension, std::string codec)
+                                                const std::string& extension, std::string codec)
   : m_FileName{ database.getName() + "." + extension }
 {
     const auto path = database.getPath() / m_FileName;

--- a/src/net/connection.cc
+++ b/src/net/connection.cc
@@ -63,7 +63,7 @@ void Connection::read(void *buffer, size_t length)
 
 Connection::SocketWriter Connection::getSocketWriter()
 {
-    return SocketWriter(*this);
+    return { *this };
 }
 
 std::string Connection::readNextCommand()

--- a/src/os/video.cc
+++ b/src/os/video.cc
@@ -42,7 +42,7 @@ std::string getCameraName(int deviceNumber)
         }
     }
 
-    return { video_cap.card };
+    return { (char *) video_cap.card };
 }
 
 std::vector<CameraDevice> getCameras()

--- a/src/os/video.cc
+++ b/src/os/video.cc
@@ -42,7 +42,7 @@ std::string getCameraName(int deviceNumber)
         }
     }
 
-    return std::string((char *) video_cap.card);
+    return { video_cap.card };
 }
 
 std::vector<CameraDevice> getCameras()

--- a/src/robots/tank/net/sink.cc
+++ b/src/robots/tank/net/sink.cc
@@ -18,7 +18,6 @@ namespace Net {
 template class SinkBase<BoBRobotics::Net::Connection &>;
 
 BundledSink::BundledSink()
-  : SinkBase<BoBRobotics::Net::Client>()
 {
     // Run client on background thread
     getConnection().runInBackground();

--- a/src/video/input.cc
+++ b/src/video/input.cc
@@ -22,7 +22,7 @@ ImgProc::OpenCVUnwrap360
 Input::createUnwrapper(const cv::Size &unwrapRes) const
 {
     // Create unwrapper and return
-    return ImgProc::OpenCVUnwrap360(getOutputSize(), unwrapRes, getCameraName());
+    return { getOutputSize(), unwrapRes, getCameraName() };
 }
 
 std::string

--- a/src/viz/sfml/sfml_world.cc
+++ b/src/viz/sfml/sfml_world.cc
@@ -66,7 +66,7 @@ SFMLWorld::SFMLWorld(const Vector2<meter_t> &arenaSize)
 SFMLWorld::CarAgent
 SFMLWorld::createCarAgent(meter_t carWidth)
 {
-    return CarAgent(*this, carWidth);
+    return { *this, carWidth };
 }
 
 bool

--- a/tools/camera_recorder/camera_recorder.cc
+++ b/tools/camera_recorder/camera_recorder.cc
@@ -50,7 +50,7 @@ int bobMain(int, char **)
     // Create motor interface
     ROBOT_TYPE motor;
 
-    cv::Mat output;
+    cv::Mat image;
     cv::Mat unwrapped(unwrapSize, CV_8UC1);
 
 #ifdef USE_VICON
@@ -77,10 +77,10 @@ int bobMain(int, char **)
         joystick.update();
 
         // If we successfully captured a frame
-        cam.readGreyscaleFrame(output);
+        cam.readGreyscaleFrame(image);
 
         // Unwrap frame
-        unwrapper.unwrap(output, unwrapped);
+        unwrapper.unwrap(image, unwrapped);
 
         // If recording interval has elapsed
         if ((x % recordingInterval) == 0) {


### PR DESCRIPTION
Closes #295.

- Revert "Jenkins: Temporarily disable clang-tidy checks"
- Apply some of clang-tidy's auto-fixes
- Add some missing virtual destructors
- Return initialiser lists in a few places
