### PR TITLE
Fix: gcc5 didn't like me default-initialising a member variable

### DIFF
--- a/include/navigation/image_database.h
+++ b/include/navigation/image_database.h
@@ -90,11 +90,16 @@ public:
     //! The metadata for an entry in an ImageDatabase
     struct Entry
     {
-        Pose3<millimeter_t, degree_t> pose = Pose3<millimeter_t, degree_t>::nan();
+        Pose3<millimeter_t, degree_t> pose;
         filesystem::path path;
         std::array<size_t, 3> gridPosition; //! For grid-type databases, indicates the x,y,z grid position
         std::unordered_map<std::string, std::string> extraFields;
 
+        Entry();
+        Entry(const Pose3<millimeter_t, degree_t> &_pose,
+              filesystem::path _path,
+              const std::array<size_t, 3> &_gridPosition,
+              std::unordered_map<std::string, std::string> _extraFields);
         cv::Mat load(bool greyscale = true) const;
         bool hasExtraField(const std::string &name) const;
         const std::string &getExtraField(const std::string &name) const;

--- a/src/navigation/image_database.cc
+++ b/src/navigation/image_database.cc
@@ -38,6 +38,20 @@ Range::size() const
     return (separation == 0_mm) ? 1 : (1 + ((end - begin) / separation).to<size_t>());
 }
 
+ImageDatabase::Entry::Entry()
+  : pose(Pose3<millimeter_t, degree_t>::nan())
+{}
+
+ImageDatabase::Entry::Entry(const Pose3<millimeter_t, degree_t> &_pose,
+                            filesystem::path _path,
+                            const std::array<size_t, 3> &_gridPosition,
+                            std::unordered_map<std::string, std::string> _extraFields)
+  : pose(_pose)
+  , path(std::move(_path))
+  , gridPosition(_gridPosition)
+  , extraFields(std::move(_extraFields))
+{}
+
 cv::Mat
 ImageDatabase::Entry::load(bool greyscale) const
 {


### PR DESCRIPTION
Errors looked like this:
```
In file included from [01m[K/home/nvidia/bob_robotics/src/navigation/image_database.cc:5:0[m[K:
[01m[K/home/nvidia/bob_robotics/include/navigation/image_database.h:93:66:[m[K [01;31m[Kerror: [m[Kexpected ‘[01m[K;[m[K’ at end of member declaration
         Pose3<millimeter_t, degree_t> pose = Pose3<millimeter_t, degree_t>::nan();
[01;32m[K                                                                  ^[m[K
[01m[K/home/nvidia/bob_robotics/include/navigation/image_database.h:93:66:[m[K [01;31m[Kerror: [m[Kdeclaration of ‘[01m[KBoBRobotics::Pose3<units::unit_t<units::unit<std::ratio<1l, 1000l>, units::unit<std::ratio<1l>, units::base_unit<std::ratio<1l> > >, std::ratio<0l, 1l>, std::ratio<0l, 1l> > >, units::unit_t<units::unit<std::ratio<1l, 180l>, units::unit<std::ratio<1l>, units::base_unit<std::ratio<0l, 1l>, std::ratio<0l, 1l>, std::ratio<0l, 1l>, std::ratio<1l> > >, std::ratio<1l> > > > BoBRobotics::Navigation::ImageDatabase::Entry::degree_t[m[K’ [-fpermissive]
[01m[K/home/nvidia/bob_robotics/include/navigation/image_database.h:82:44:[m[K [01;31m[Kerror: [m[Kchanges meaning of ‘[01m[Kdegree_t[m[K’ from ‘[01m[Kusing degree_t = units::angle::degree_t[m[K’ [-fpermissive]
     using degree_t = units::angle::degree_t;
[01;32m[K                                            ^[m[K
[01m[K/home/nvidia/bob_robotics/include/navigation/image_database.h:93:74:[m[K [01;31m[Kerror: [m[Kexpected unqualified-id before ‘[01m[K>[m[K’ token
         Pose3<millimeter_t, degree_t> pose = Pose3<millimeter_t, degree_t>::nan();
[01;32m[K                                                                          ^[m[K
[01m[K/home/nvidia/bob_robotics/include/navigation/image_database.h:93:52:[m[K [01;31m[Kerror: [m[Kwrong number of template arguments (1, should be 2)
         Pose3<millimeter_t, degree_t> pose = Pose3<millimeter_t, degree_t>::nan();
[01;32m[K                                                    ^[m[K
In file included from [01m[K/home/nvidia/bob_robotics/include/navigation/image_database.h:6:0[m[K,
                 from [01m[K/home/nvidia/bob_robotics/src/navigation/image_database.cc:5[m[K:
[01m[K/home/nvidia/bob_robotics/include/common/pose.h:23:7:[m[K [01;36m[Knote: [m[Kprovided for ‘[01m[Ktemplate<class LengthUnit, class AngleUnit> class BoBRobotics::Pose3[m[K’
 class Pose3;
[01;32m[K       ^[m[K
[01m[K/home/nvidia/bob_robotics/src/navigation/image_database.cc:[m[K In member function ‘[01m[Kbool BoBRobotics::Navigation::ImageDatabase::loadCSV()[m[K’:
[01m[K/home/nvidia/bob_robotics/src/navigation/image_database.cc:402:9:[m[K [01;31m[Kerror: [m[Kcould not convert ‘[01m[K((! BoBRobotics::Navigation::ImageDatabase::isVideoType()) ? filesystem::path::operator/(const filesystem::path&) const(filesystem::path(BoBRobotics::Navigation::ImageDatabase::loadCSV()::<lambda(size_t)>(4ul))) : filesystem::path())[m[K’ from ‘[01m[Kfilesystem::path[m[K’ to ‘[01m[KBoBRobotics::Pose3<units::unit_t<units::unit<std::ratio<1l, 1000l>, units::unit<std::ratio<1l>, units::base_unit<std::ratio<1l> > >, std::ratio<0l, 1l>, std::ratio<0l, 1l> > >, units::unit_t<units::unit<std::ratio<1l, 180l>, units::unit<std::ratio<1l>, units::base_unit<std::ratio<0l, 1l>, std::ratio<0l, 1l>, std::ratio<0l, 1l>, std::ratio<1l> > >, std::ratio<1l> > > >[m[K’
         };
[01;32m[K         ^[m[K
[01m[K/home/nvidia/bob_robotics/src/navigation/image_database.cc:402:9:[m[K [01;31m[Kerror: [m[Kcould not convert ‘[01m[KgridPosition[m[K’ from ‘[01m[Kstd::array<long unsigned int, 3ul>[m[K’ to ‘[01m[Kfilesystem::path[m[K’
[01m[K/home/nvidia/bob_robotics/src/navigation/image_database.cc:402:9:[m[K [01;31m[Kerror: [m[Kcannot convert ‘[01m[Kstd::remove_reference<std::unordered_map<std::__cxx11::basic_string<char>, std::__cxx11::basic_string<char> >&>::type {aka std::unordered_map<std::__cxx11::basic_string<char>, std::__cxx11::basic_string<char> >}[m[K’ to ‘[01m[Klong unsigned int[m[K’ in initialization
[01m[K/home/nvidia/bob_robotics/src/navigation/image_database.cc:402:9:[m[K [01;35m[Kwarning: [m[Kmissing initializer for member ‘[01m[KBoBRobotics::Navigation::ImageDatabase::Entry::extraFields[m[K’ [-Wmissing-field-initializers]
BoB/modules/navigation/CMakeFiles/bob_navigation.dir/build.make:75: recipe for target 'BoB/modules/navigation/CMakeFiles/bob_navigation.dir/image_database.cc.o' failed
make[2]: *** [BoB/modules/navigation/CMakeFiles/bob_navigation.dir/image_database.cc.o] Error 1
CMakeFiles/Makefile2:739: recipe for target 'BoB/modules/navigation/CMakeFiles/bob_navigation.dir/all' failed
make[1]: *** [BoB/modules/navigation/CMakeFiles/bob_navigation.dir/all] Error 2
Makefile:90: recipe for target 'all' failed
make: *** [all] Error 2
```

Yet another reason to upgrade from Ubuntu 16.04 :smile: 

@FullAPVayne Could you test this for me before we merge? Sorry, I should have got someone to test my code on the robot before I merged #306 !