### PR TITLE
Refactor: Transpose matrix returned by PM algos

### DIFF
--- a/include/navigation/perfect_memory.h
+++ b/include/navigation/perfect_memory.h
@@ -234,7 +234,7 @@ public:
         tbb::parallel_for(tbb::blocked_range<size_t>(0, numSnapshots),
                           [&](const auto &r) {
                               for (size_t i = r.begin(); i != r.end(); ++i) {
-                                  m_MinimumDifferences[i] = m_RotatedDifferences.row(i).minCoeff(&m_BestColumns[i]);
+                                  m_MinimumDifferences[i] = m_RotatedDifferences.col(i).minCoeff(&m_BestColumns[i]);
                               }
                           });
 
@@ -285,7 +285,7 @@ private:
         BOB_ASSERT(window.first < window.second);
 
         // Preallocate snapshot difference vectors
-        m_RotatedDifferences.resize(window.second - window.first, rotater.numRotations());
+        m_RotatedDifferences.resize(rotater.numRotations(), window.second - window.first);
 
         // Scan across image columns
         rotater.rotate(
@@ -293,7 +293,7 @@ private:
                     // Loop through snapshots
                     for (size_t s = window.first; s < window.second; s++) {
                         // Calculate difference
-                        m_RotatedDifferences(s - window.first, i) = this->calcSnapshotDifference(fr, mask, s);
+                        m_RotatedDifferences(i, s - window.first) = this->calcSnapshotDifference(fr, mask, s);
                     }
                 });
     }

--- a/python/navigation/src/algos.cc
+++ b/python/navigation/src/algos.cc
@@ -8,9 +8,6 @@
 // Third-party includes
 #include "range/v3/view.hpp"
 
-// Eigen
-#include <Eigen/Core>
-
 // Standard C++ includes
 #include <stdexcept>
 
@@ -188,17 +185,11 @@ public:
                               toRange<size_t>(bestSnap),
                               ranges::back_inserter(bestRIDF),
                               [&](const auto &diffs, const auto &bestSnap) {
-                                  const size_t cols = diffs.shape(1);
-                                  const size_t rows = diffs.shape(0);
+                                  const size_t cols = diffs.shape(0);
 
                                   // Extract the row corresponding to the best-matching snap
-                                  const Eigen::Map<const Eigen::ArrayXXf> diffsMat(diffs.data(), rows, cols);
-                                  py::array_t<float> ridf{ static_cast<py::ssize_t>(cols) };
-                                  auto *outPtr = ridf.mutable_data();
-                                  for (size_t i = 0; i < cols; i++) {
-                                      outPtr[i] = diffsMat(bestSnap, i);
-                                  }
-                                  return ridf;
+                                  const float *ptr = &diffs.data()[bestSnap * cols];
+                                  return py::array_t<float>(cols, ptr, diffs);
                               });
             df["ridf"] = std::move(bestRIDF);
         }


### PR DESCRIPTION
This means that individual RIDFs are contiguous in memory making things
more efficient and making it easier to copy these values out again.
