### PR TITLE
``snapshot_bot``: Refactor ``ImageInput`` code so it's easier to extend

### DIFF
--- a/projects/snapshot_bot/config.cc
+++ b/projects/snapshot_bot/config.cc
@@ -39,9 +39,7 @@ void readIntegerSize(const cv::FileNode &node, size_t &value, size_t defaultValu
 }
 
 Config::Config()
-  : m_UseBinaryImage(false)
-  , m_UseHorizonVector(false)
-  , m_UseHistEq(false)
+  : m_ImageInputType("raw")
   , m_Train(true)
   , m_UseInfoMax(false)
   , m_SaveTestingDiagnostic(false)
@@ -100,10 +98,9 @@ void
 Config::read(const cv::FileNode &node)
 {
         // Read settings
-        // **NOTE** we use cv::read rather than stream operators as we want to use current values as defaults
-        cv::read(node["shouldUseBinaryImage"], m_UseBinaryImage, m_UseBinaryImage);
-        cv::read(node["shouldUseHorizonVector"], m_UseHorizonVector, m_UseHorizonVector);
-        cv::read(node["shouldUseHistEq"], m_UseHistEq, m_UseHistEq);
+        // **NOTE** we use cv::read rather than stream operators as we want to
+        // use current values as defaults
+        cv::read(node["imageInputType"], m_ImageInputType, m_ImageInputType);
         cv::read(node["shouldTrain"], m_Train, m_Train);
         cv::read(node["shouldUseInfoMax"], m_UseInfoMax, m_UseInfoMax);
         cv::read(node["shouldSaveTestingDiagnostic"], m_SaveTestingDiagnostic, m_SaveTestingDiagnostic);
@@ -115,10 +112,6 @@ Config::read(const cv::FileNode &node)
         cv::read(node["shouldUseIMU"], m_UseIMU, m_UseIMU);
         cv::read(node["videoCodec"], m_VideoCodec, m_VideoCodec);
         cv::read(node["videoFileExtension"], m_VideoFileExtension, m_VideoFileExtension);
-
-
-        // Assert that configuration is valid
-        BOB_ASSERT(!m_UseBinaryImage || !m_UseHorizonVector);
 
         // **YUCK** why does OpenCV (at least my version) not have a cv::read overload for std::string!?
         cv::String outputPath;
@@ -222,9 +215,7 @@ void
 Config::write(cv::FileStorage &fs) const
 {
     fs << "{";
-    fs << "shouldUseBinaryImage" << shouldUseBinaryImage();
-    fs << "shouldUseHorizonVector" << shouldUseHorizonVector();
-    fs << "shouldUseHistEq" << shouldUseHistEq();
+    fs << "imageInputType" << getImageInputType();
     fs << "shouldTrain" << shouldTrain();
     fs << "shouldUseInfoMax" << shouldUseInfoMax();
     fs << "shouldSaveTestingDiagnostic" << shouldSaveTestingDiagnostic();

--- a/projects/snapshot_bot/config.h
+++ b/projects/snapshot_bot/config.h
@@ -30,9 +30,6 @@ public:
     //------------------------------------------------------------------------
     // Public API
     //------------------------------------------------------------------------
-    bool shouldUseBinaryImage() const{ return m_UseBinaryImage; }
-    bool shouldUseHorizonVector() const{ return m_UseHorizonVector; }
-    bool shouldUseHistEq() const{ return m_UseHistEq; }
     bool shouldTrain() const{ return m_Train; }
     bool shouldUseInfoMax() const{ return m_UseInfoMax; }
     bool shouldSaveTestingDiagnostic() const{ return m_SaveTestingDiagnostic; }
@@ -42,6 +39,7 @@ public:
     bool shouldDriveRobot() const{ return m_DriveRobot; }
     bool shouldRecordVideo() const{ return m_RecordVideo; }
 
+    const std::string &getImageInputType() const{ return m_ImageInputType; }
     const std::string &getVideoCodec() const{ return m_VideoCodec; }
     const std::string &getVideoFileExtension() const{ return m_VideoFileExtension; }
 
@@ -98,11 +96,7 @@ private:
     //------------------------------------------------------------------------
     // Members
     //------------------------------------------------------------------------
-    bool m_UseBinaryImage;
-
-    bool m_UseHorizonVector;
-
-    bool m_UseHistEq;
+    std::string m_ImageInputType;
 
     // Should we start in training mode or use existing data?
     bool m_Train;

--- a/projects/snapshot_bot/image_input.h
+++ b/projects/snapshot_bot/image_input.h
@@ -69,6 +69,8 @@ public:
     //----------------------------------------------------------------------------
     virtual std::pair<cv::Mat, Mask> processSnapshot(const cv::Mat &snapshot) override;
 
+    static constexpr const char *OptionName = "raw";
+
 private:
     cv::Mat m_Greyscale;
 };
@@ -86,6 +88,8 @@ public:
     // ImageInput virtuals
     //----------------------------------------------------------------------------
     virtual std::pair<cv::Mat, Mask> processSnapshot(const cv::Mat &snapshot) override;
+
+    static constexpr const char *OptionName = "histeq";
 
 private:
     cv::Mat m_HistEq;
@@ -105,6 +109,8 @@ public:
     //----------------------------------------------------------------------------
     virtual std::pair<cv::Mat, Mask> processSnapshot(const cv::Mat &snapshot) override;
     virtual cv::Size getOutputSize() const override { return cv::Size(getUnwrapSize().width - 2, getUnwrapSize().height - 2); }
+
+    static constexpr const char *OptionName = "binary";
 
 protected:
     //----------------------------------------------------------------------------
@@ -151,6 +157,8 @@ public:
     {
         return cv::Size(getUnwrapSize().width - 2, 1);
     }
+
+    static constexpr const char *OptionName = "horizon";
 
 private:
     //----------------------------------------------------------------------------


### PR DESCRIPTION
This removes some of the boilerplate and replaces the multiple boolean options with a single string one.

This currently won't build on the Mecanum robot as gcc v5 seems not to like the ranges library. My plan is to reflash the Jetson with a newer version of Ubuntu so we can test this change properly.