### PR TITLE
Fix Jenkins linking errors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,15 @@ project(bob_robotics)
 
 add_subdirectory(examples)
 add_subdirectory(projects)
-add_subdirectory(python)
 add_subdirectory(tests)
 add_subdirectory(tests/navigation)
 add_subdirectory(tools)
+
+# The included Python code can't actually be built by CMake in this way (you
+# need to use the setup.py script), but we include it anyway for IDEs that use
+# CMake to get include paths etc. so you can get autocomplete. Hence if we
+# *actually* want to test that the code builds (i.e. via Jenkins) then including
+# this subdirectory will break things. (The Python build is tested separately.)
+if(NOT BUILD_TEST)
+    add_subdirectory(python)
+endif()

--- a/bin/build_all_jenkins.sh
+++ b/bin/build_all_jenkins.sh
@@ -19,5 +19,5 @@ cd build
 # it and it's easier just to enable it everywhere. If we don't do this then we
 # get errors when trying to link shared library files against the BoB static
 # libraries.
-cmake -DCMAKE_CXX_FLAGS=-fPIC -DCMAKE_EXPORT_COMPILE_COMMANDS=1 "$@" ..
+cmake -DCMAKE_CXX_FLAGS=-fPIC -DCMAKE_EXPORT_COMPILE_COMMANDS=1 -DBUILD_TEST=ON "$@" ..
 make -k -j $(nproc)


### PR DESCRIPTION
This is currently causing tests to fail. The cause seems to be that the Python
module's C++ code won't compile properly via the root CMakeLists.txt file, which
is fine as it can't be built that way anyway (it's only included so that IDEs
can get info about the source files).

So let's just disable building Python C++ code on Jenkins. It's already
build-tested separately anyways.