### PR TITLE
Add tool to rewrite snapshot_bot config files

### DIFF
--- a/projects/snapshot_bot/CMakeLists.txt
+++ b/projects/snapshot_bot/CMakeLists.txt
@@ -46,6 +46,9 @@ add_custom_command(TARGET snapshot_bot
 add_executable(offline_train offline_train.cc)
 target_link_libraries(offline_train PRIVATE snapshot_bot_common)
 
+add_executable(rewrite_config rewrite_config.cc)
+target_link_libraries(rewrite_config PRIVATE snapshot_bot_common)
+
 configure_file(mask.png "${CMAKE_CURRENT_BINARY_DIR}" COPYONLY)
 configure_file(segmentation.png "${CMAKE_CURRENT_BINARY_DIR}" COPYONLY)
 configure_file(config_demo.yaml "${CMAKE_CURRENT_BINARY_DIR}" COPYONLY)

--- a/projects/snapshot_bot/config_demo.yaml
+++ b/projects/snapshot_bot/config_demo.yaml
@@ -1,8 +1,7 @@
 %YAML:1.0
 ---
 config:
-   shouldUseBinaryImage: 0
-   shouldUseHorizonVector: 0
+   imageInputType: raw
    shouldTrain: 1
    shouldUseInfoMax: 0
    shouldSaveTestingDiagnostic: 1
@@ -10,6 +9,7 @@ config:
    shouldUseODK2: 0
    shouldUseWebcam: 0
    shouldDriveRobot: 1
+   shouldUseIMU: 0
    outputPath: demo
    shouldRecordVideo: 1
    videoCodec: XVID
@@ -25,6 +25,7 @@ config:
    maskImageFilename: ""
    watershedMarkerImageFilename: "segmentation.png"
    joystickDeadzone: 2.5000000000000000e-01
+   joystickGain: 1.
    autoTrain: 1
    trainInterval: 100.
    testFrameSkip: 1

--- a/projects/snapshot_bot/config_demo_testing.yaml
+++ b/projects/snapshot_bot/config_demo_testing.yaml
@@ -1,8 +1,7 @@
 %YAML:1.0
 ---
 config:
-   shouldUseBinaryImage: 0
-   shouldUseHorizonVector: 0
+   imageInputType: raw
    shouldTrain: 0
    shouldUseInfoMax: 0
    shouldSaveTestingDiagnostic: 1
@@ -10,6 +9,7 @@ config:
    shouldUseODK2: 0
    shouldUseWebcam: 0
    shouldDriveRobot: 1
+   shouldUseIMU: 0
    outputPath: demo
    shouldRecordVideo: 1
    videoCodec: XVID
@@ -25,6 +25,7 @@ config:
    maskImageFilename: ""
    watershedMarkerImageFilename: "segmentation.png"
    joystickDeadzone: 2.5000000000000000e-01
+   joystickGain: 1.
    autoTrain: 1
    trainInterval: 100.
    testFrameSkip: 1

--- a/projects/snapshot_bot/rewrite_config.cc
+++ b/projects/snapshot_bot/rewrite_config.cc
@@ -1,0 +1,28 @@
+#include "config.h"
+
+// BoB robotics includes
+#include "common/macros.h"
+
+// Standard C++ includes
+#include <iostream>
+
+int bobMain(int argc, char **argv)
+{
+    BOB_ASSERT(argc > 1);
+
+    for (size_t i = 1; i < (size_t) argc; i++) {
+        std::cout << "Rewriting " << argv[i] << "\n";
+
+        Config config;
+        {
+            cv::FileStorage fs(argv[i], cv::FileStorage::READ);
+            fs["config"] >> config;
+        }
+        {
+            cv::FileStorage fs(argv[i], cv::FileStorage::WRITE);
+            fs << "config" << config;
+        }
+    }
+
+    return EXIT_SUCCESS;
+}


### PR DESCRIPTION
I've added a program to rewrite snapshot_bot config files to remove old options and put new ones in.

I've mostly just added a few options over the last while *however* note that you now set ``imageInputType`` to a string (e.g., ``raw``, ``histeq``) rather than the old ``shouldUseHistEq``-type boolean options. Make sure you don't get bitten by this! @FullAPVayne @efkag 