### PR TITLE
Infomax tweaks curtesy of Amany

### DIFF
--- a/examples/infomax/infomax_matlab_comparison.cc
+++ b/examples/infomax/infomax_matlab_comparison.cc
@@ -51,21 +51,21 @@ runTest(const filesystem::path &dataPath, int num)
 
     // Make our InfoMax runner object
     using InfoMaxType = InfoMaxRotater<double>;
-    InfoMaxType infomax(image.size(), InfoMaxType::DefaultLearningRate,
+    InfoMaxType infomax(image.size(), InfoMaxType::DefaultLearningRate * imageMatrix.rows() * imageMatrix.cols(),
                         InfoMaxType::DefaultTanhScalingFactor,
                         Normalisation::None, std::move(initWeights));
+    
+    LOGI << "Weights before training: "
+         << infomax.getWeights();
+
+    LOGI << "Image: "
+         << imageMatrix.cast<int>();
 
     // Do training
     Matrix<double, Dynamic, 1> u, y;
     infomax.calculateUY(image);
     std::tie(u, y) = infomax.getUY();
     infomax.trainUY();
-
-    LOGI << "Weights before training: "
-         << infomax.getWeights();
-
-    LOGI << "Image: "
-         << imageMatrix.cast<int>();
 
     LOGI << "U: " << u;
     LOGI << "Y: " << y;

--- a/examples/infomax/infomax_matlab_comparison.cc
+++ b/examples/infomax/infomax_matlab_comparison.cc
@@ -51,8 +51,7 @@ runTest(const filesystem::path &dataPath, int num)
 
     // Make our InfoMax runner object
     using InfoMaxType = InfoMaxRotater<double>;
-    InfoMaxType infomax(image.size(), InfoMaxType::DefaultLearningRate * imageMatrix.rows() * imageMatrix.cols(),
-                        InfoMaxType::DefaultTanhScalingFactor,
+    InfoMaxType infomax(image.size(), 0.0001 * imageMatrix.rows() * imageMatrix.cols(),
                         Normalisation::None, std::move(initWeights));
     
     LOGI << "Weights before training: "

--- a/examples/infomax/infomax_route_example.cc
+++ b/examples/infomax/infomax_route_example.cc
@@ -121,18 +121,17 @@ int bobMain(int argc, char **argv)
             + "_reps"s + std::to_string(numReps) + ".bin"s;
 
     constexpr auto LearningRate = InfoMaxType::DefaultLearningRate;
-    constexpr auto TanhScalingFactor = InfoMaxType::DefaultTanhScalingFactor;
 
     // If we already have a network for these params, load from disk
     if (netPath.exists()) {
         LOGI << "Loading weights from " << netPath;
 
-        InfoMaxType infomax(imSize, LearningRate, TanhScalingFactor,
-                            Normalisation::None, readMatrix<FloatType>(netPath));
+        InfoMaxType infomax(imSize, LearningRate, Normalisation::None, 
+                            readMatrix<FloatType>(netPath));
         doTesting(infomax, route, images);
     } else {
         // ...otherwise do the training now
-        InfoMaxType infomax(imSize, LearningRate, TanhScalingFactor);
+        InfoMaxType infomax(imSize, LearningRate);
 
         // Train network
         {

--- a/include/navigation/infomax.h
+++ b/include/navigation/infomax.h
@@ -53,17 +53,14 @@ public:
     using MatrixType = Eigen::Matrix<FloatType, Eigen::Dynamic, Eigen::Dynamic>;
     using VectorType = Eigen::Matrix<FloatType, Eigen::Dynamic, 1>;
 
-    static constexpr FloatType DefaultLearningRate{ 0.01 };
-    static constexpr FloatType DefaultTanhScalingFactor{ 0.1 };
+    static constexpr FloatType DefaultLearningRate{ 0.97 };
 
     InfoMax(const cv::Size &unwrapRes,
             FloatType learningRate,
-            FloatType tanhScalingFactor,
             Normalisation normalisation,
             MatrixType initialWeights)
       : m_UnwrapRes(unwrapRes)
       , m_LearningRate(learningRate)
-      , m_TanhScalingFactor(tanhScalingFactor)
       , m_Normalisation(normalisation)
       , m_Weights(std::move(initialWeights))
     {
@@ -72,19 +69,17 @@ public:
 
     InfoMax(const cv::Size &unwrapRes, unsigned int numHidden,
             FloatType learningRate = DefaultLearningRate,
-            FloatType tanhScalingFactor = DefaultTanhScalingFactor,
             Normalisation normalisation = Normalisation::None)
-      : InfoMax(unwrapRes, learningRate, tanhScalingFactor, normalisation,
+      : InfoMax(unwrapRes, learningRate, normalisation,
                 generateInitialWeights(unwrapRes.width * unwrapRes.height, 
                                        numHidden))
     {}
 
     InfoMax(const cv::Size &unwrapRes,
             FloatType learningRate = DefaultLearningRate,
-            FloatType tanhScalingFactor = DefaultTanhScalingFactor,
             Normalisation normalisation = Normalisation::None)
       : InfoMax(unwrapRes, unwrapRes.width * unwrapRes.height, learningRate, 
-                tanhScalingFactor, normalisation)
+                normalisation)
     {}
 
     
@@ -112,11 +107,6 @@ public:
     float getLearningRate() const
     {
         return m_LearningRate;
-    }
-
-    float getTanhScalingFactor() const
-    {
-        return m_TanhScalingFactor;
     }
 
     Normalisation getNormalisationMethod() const
@@ -193,7 +183,7 @@ public:
 
         // Convert image to vector of floats
         // **NOTE** m_Weights is MxN matrix and input is a Nx1 column vector so m_U and m_Y and Mx1 column vectors
-        m_U = m_Weights * getNetInputs(image) * m_TanhScalingFactor;
+        m_U = m_Weights * getNetInputs(image);
         m_Y = tanh(m_U.array());
     }
 
@@ -210,7 +200,7 @@ public:
 
 private:
     const cv::Size m_UnwrapRes;
-    const FloatType m_LearningRate, m_TanhScalingFactor;
+    const FloatType m_LearningRate;
     const Normalisation m_Normalisation;
     MatrixType m_Weights;
     VectorType m_U, m_Y;
@@ -259,11 +249,8 @@ class InfoMaxRotater : public InfoMax<FloatType>
 {
 public:
     using MatrixType = Eigen::Matrix<FloatType, Eigen::Dynamic, Eigen::Dynamic>;
-
-    template<class... Ts>
-    InfoMaxRotater(Ts&&... args)
-      : InfoMax<FloatType>(std::forward<Ts>(args)...)
-    {}
+    
+    using InfoMax<FloatType>::InfoMax;
 
     //------------------------------------------------------------------------
     // Public API
@@ -338,7 +325,5 @@ private:
 template<class T>
 constexpr T InfoMax<T>::DefaultLearningRate;
 
-template<class T>
-constexpr T InfoMax<T>::DefaultTanhScalingFactor;
 } // Navigation
 } // BoBRobotics

--- a/include/navigation/infomax.h
+++ b/include/navigation/infomax.h
@@ -184,7 +184,7 @@ public:
         // Convert image to vector of floats
         // **NOTE** m_Weights is MxN matrix and input is a Nx1 column vector so m_U and m_Y and Mx1 column vectors
         m_U = m_Weights * getNetInputs(image);
-        m_Y = tanh(m_U.array());
+        m_Y = m_U.array().tanh();
     }
 
     std::pair<VectorType, VectorType> getUY() const

--- a/include/navigation/infomax.h
+++ b/include/navigation/infomax.h
@@ -70,14 +70,24 @@ public:
         BOB_ASSERT(m_Weights.cols() == unwrapRes.width * unwrapRes.height);
     }
 
-    InfoMax(const cv::Size &unwrapRes,
+    InfoMax(const cv::Size &unwrapRes, unsigned int numHidden,
             FloatType learningRate = DefaultLearningRate,
             FloatType tanhScalingFactor = DefaultTanhScalingFactor,
             Normalisation normalisation = Normalisation::None)
       : InfoMax(unwrapRes, learningRate, tanhScalingFactor, normalisation,
-                generateInitialWeights(unwrapRes.width * unwrapRes.height,
-                                       unwrapRes.width * unwrapRes.height))
+                generateInitialWeights(unwrapRes.width * unwrapRes.height, 
+                                       numHidden))
     {}
+
+    InfoMax(const cv::Size &unwrapRes,
+            FloatType learningRate = DefaultLearningRate,
+            FloatType tanhScalingFactor = DefaultTanhScalingFactor,
+            Normalisation normalisation = Normalisation::None)
+      : InfoMax(unwrapRes, unwrapRes.width * unwrapRes.height, learningRate, 
+                tanhScalingFactor, normalisation)
+    {}
+
+    
 
     //------------------------------------------------------------------------
     // Public API
@@ -96,7 +106,7 @@ public:
     //! Generates new random weights
     void clearMemory()
     {
-        m_Weights = generateInitialWeights(m_Weights.cols(), m_Weights.rows());
+        m_Weights = generateInitialWeights(getNumInputs(), getNumHidden());
     }
 
     float getLearningRate() const
@@ -150,12 +160,14 @@ public:
 #endif
     void trainUY()
     {
-        // weights = weights + lrate/N * (eye(H)-(y+u)*u') * weights;
-        const auto id = MatrixType::Identity(m_Weights.rows(), m_Weights.rows());
-        const auto sumYU = (m_Y.array() + m_U.array()).matrix();
-        const FloatType learnRate = m_LearningRate / (FloatType) m_U.rows();
+        // weights = weights + lrate/N.M * (eye(M)-(y+u)*u') * weights;
+        // **NOTE** additional scaling after M from Azevedo et al. 2023
+        const auto id = MatrixType::Identity(getNumHidden(), getNumHidden());
+        const FloatType learnRate = m_LearningRate / (FloatType)(getNumInputs() * getNumHidden());
 
-        m_Weights.array() += (learnRate * (id - sumYU * m_U.transpose()) * m_Weights).array();
+        // **NOTE** middle term evaluates to MxM matrix, m_Weights are M*N,
+        // meaning result is M*N as required for adding back to m_Weights
+        m_Weights += (learnRate * (id - ((m_Y + m_U) * m_U.transpose())) * m_Weights);
 
         /*
          * If the learning rate is too high, we may end up with NaNs in our
@@ -180,6 +192,7 @@ public:
         BOB_ASSERT(image.rows == unwrapRes.height);
 
         // Convert image to vector of floats
+        // **NOTE** m_Weights is MxN matrix and input is a Nx1 column vector so m_U and m_Y and Mx1 column vectors
         m_U = m_Weights * getNetInputs(image) * m_TanhScalingFactor;
         m_Y = tanh(m_U.array());
     }
@@ -202,14 +215,14 @@ private:
     MatrixType m_Weights;
     VectorType m_U, m_Y;
 
-    template<class T>
-    static auto toZScore(const T &vec)
+    Eigen::Index getNumInputs() const
     {
-        const FloatType mean = vec.mean();
+        return m_Weights.cols();
+    }
 
-        const auto vNorm = vec.array() - mean;
-        const FloatType sd = std::sqrt((vNorm * vNorm).mean());
-        return vNorm / sd;
+    Eigen::Index getNumHidden() const
+    {
+        return m_Weights.rows();
     }
 
     //! Converts image to VectorType and normalises
@@ -218,13 +231,15 @@ private:
         Eigen::Map<Eigen::Matrix<uint8_t, Eigen::Dynamic, 1>> map(image.data, image.cols * image.rows);
         const auto vec = map.cast<FloatType>();
 
-        switch (m_Normalisation) {
-        case Normalisation::None:
+        if(m_Normalisation == Normalisation::None) {
             return vec / 255.0;
-        case Normalisation::ZScore:
-            return toZScore(vec);
-        default:
-            throw std::runtime_error{ "Invalid normalisation method" };
+        }
+        else {
+            const FloatType mean = vec.mean();
+
+            const auto vNorm = vec.array() - mean;
+            const FloatType sd = std::sqrt((vNorm * vNorm).mean());
+            return vNorm / sd;
         }
     }
 

--- a/projects/snapshot_bot/memory.cc
+++ b/projects/snapshot_bot/memory.cc
@@ -296,7 +296,6 @@ InfoMax::InfoMaxType InfoMax::createInfoMax(const Config &config, const cv::Size
 
         const auto weights = readMatrix<InfoMaxWeightMatrixType::Scalar>(weightPath);
         return { inputSize, InfoMaxType::DefaultLearningRate,
-                 InfoMaxType::DefaultTanhScalingFactor,
                  Navigation::Normalisation::None, weights };
     } else {
         return { inputSize };

--- a/python/navigation/src/algos.cc
+++ b/python/navigation/src/algos.cc
@@ -235,9 +235,9 @@ class PyAlgoWrapper<InfoMaxType>
 {
 public:
     PyAlgoWrapper(const cv::Size &size, float learningRate,
-                  float tanhScalingFactor, Normalisation normalisation,
+                  Normalisation normalisation,
                   const optional<unsigned> &seed, optional<Eigen::MatrixXf> weights)
-      : PyAlgoWrapperBase<InfoMaxType>(size, learningRate, tanhScalingFactor, normalisation, createWeights(size, seed, std::move(weights)))
+      : PyAlgoWrapperBase<InfoMaxType>(size, learningRate, normalisation, createWeights(size, seed, std::move(weights)))
     {}
 
     const auto &getWeights() const
@@ -371,16 +371,14 @@ addAlgorithmClasses(py::module &m)
             .def(py::init([](const optional<cv::Size> &size,
                              const optional<ImageSet> &trainImages,
                              float learningRate,
-                             float tanhScalingFactor,
                              Normalisation normalisation,
                              const optional<unsigned> &seed,
                              optional<Eigen::MatrixXf> weights) {
-                     return createAlgo<InfoMaxType>(size, trainImages, learningRate, tanhScalingFactor, normalisation, seed, std::move(weights));
+                     return createAlgo<InfoMaxType>(size, trainImages, learningRate, normalisation, seed, std::move(weights));
                  }),
                  "size"_a = nullopt,
                  "train_images"_a = nullopt,
                  "learning_rate"_a = InfoMaxType::DefaultLearningRate,
-                 "tanh_scaling_factor"_a = InfoMaxType::DefaultTanhScalingFactor,
                  "normalisation"_a = Normalisation::None,
                  "seed"_a = nullopt,
                  "weights"_a = nullopt)
@@ -390,7 +388,6 @@ addAlgorithmClasses(py::module &m)
                         return py::make_tuple(
                                 infomax.getUnwrapResolution(),
                                 infomax.getLearningRate(),
-                                infomax.getTanhScalingFactor(),
                                 infomax.getNormalisationMethod(),
                                 infomax.getWeights());
                     },
@@ -406,8 +403,7 @@ addAlgorithmClasses(py::module &m)
                     }))
             .def("get_weights", &PyAlgoWrapper<InfoMaxType>::getWeights)
             .def_static("generate_initial_weights", &PyAlgoWrapper<InfoMaxType>::generateInitialWeights, "size"_a, "num_hidden"_a = ::optional<int>{}, "seed"_a = ::optional<unsigned>{})
-            .def_property_readonly_static("DEFAULT_LEARNING_RATE", [](const py::object &) { return InfoMaxType::DefaultLearningRate; })
-            .def_property_readonly_static("DEFAULT_TANH_SCALING_FACTOR", [](const py::object &) { return InfoMaxType::DefaultTanhScalingFactor; });
+            .def_property_readonly_static("DEFAULT_LEARNING_RATE", [](const py::object &) { return InfoMaxType::DefaultLearningRate; });
 }
 } // Navigation
 } // BoBRobotics

--- a/src/navigation/image_database.cc
+++ b/src/navigation/image_database.cc
@@ -351,7 +351,7 @@ ImageDatabase::loadCSV()
             extraFieldNames.emplace(i, std::move(fields[i]));
         }
     }
-
+    
     // Sanity check the file: we need the first four columns
     const auto validIdx = [](int idx) {
         return idx != -1;
@@ -363,15 +363,15 @@ ImageDatabase::loadCSV()
      * make sense for video-type ones.
      */
     BOB_ASSERT(validIdx(fieldNameIdx[4]) == !isVideoType());
-
+    
     // Assume it's a grid if we have any of the Grid fields...
     if (!hasMetadata()) {
-        m_IsRoute = !std::any_of(fieldNameIdx.cbegin() + 5, fieldNameIdx.cend(), validIdx);
+        m_IsRoute = !std::any_of(fieldNameIdx.cbegin() + 5, fieldNameIdx.cbegin() + 8, validIdx);
     }
 
     // ...but we require *all* Grid fields for it to be valid
     if (!m_IsRoute) {
-        BOB_ASSERT(std::all_of(fieldNameIdx.cbegin() + 5, fieldNameIdx.cend(), validIdx));
+        BOB_ASSERT(std::all_of(fieldNameIdx.cbegin() + 5, fieldNameIdx.cbegin() + 8, validIdx));
     }
 
     // Read data line by line


### PR DESCRIPTION
* Added comments to help future-self
* Now scale weight update by ``N*M`` not just N (pretty sure previously the code actually used ``M``)
* Allow number of hidden units to be specified separately
* Removed unnecessary ``array()`` and ``matrix()`` calls: + and - are always element-wise operations - @alexdewar is there a reason for these I'm not just getting?
* Removed tanh scaling - @amanyazevedoamin tells me it was a detour enroute to discovering the actual problem (updates should scaled as described above)

@amanyazevedoamin  - is there a more sensible default learning rate we should now use?
@alexdewar - after counteracting the learning rate scale, output of ``infomax_matlab_comparison`` is the same as before but differences are non-zero - what's going on here?