### PR TITLE
Robot dead reckoning

### DIFF
--- a/include/robots/omni2d/mecanum.h
+++ b/include/robots/omni2d/mecanum.h
@@ -19,17 +19,18 @@ namespace Omni2D {
 // BoBRobotics::Robots::Omni2D::Mecanum
 //----------------------------------------------------------------------------
 class Mecanum
-  : public Omni2DBase<Mecanum>
-{
+  : public Omni2DBase<Mecanum>{
+    friend Omni2DBase<Mecanum>;
 public:
     Mecanum(bool alternativeWiring = true,
             const char *path = SerialInterface::DefaultLinuxDevicePath);
     ~Mecanum();
 
-    void omni2D(float forward, float sideways, float turn);
-
     //! Drive robot using individual motor speeds - all range from -1 to 1
     void driveMotors(float m1, float m2, float m3, float m4);
+
+protected:
+    void omni2DInternal(float forward, float sideways, float turn);
 
 private:
     //----------------------------------------------------------------------------
@@ -49,6 +50,7 @@ private:
     {
         m_Serial.write(data);
     }
+
 }; // Mecanum
 } // Omni2D
 } // Robots

--- a/include/robots/omni2d/mecanum.h
+++ b/include/robots/omni2d/mecanum.h
@@ -18,8 +18,8 @@ namespace Omni2D {
 //----------------------------------------------------------------------------
 // BoBRobotics::Robots::Omni2D::Mecanum
 //----------------------------------------------------------------------------
-class Mecanum
-  : public Omni2DBase<Mecanum>{
+class Mecanum : public Omni2DBase<Mecanum>
+{
     friend Omni2DBase<Mecanum>;
 public:
     Mecanum(bool alternativeWiring = true,
@@ -33,12 +33,6 @@ protected:
     void omni2DInternal(float forward, float sideways, float turn);
 
 private:
-    //----------------------------------------------------------------------------
-    // Private members
-    //----------------------------------------------------------------------------
-    const bool m_AlternativeWiring;
-    SerialInterface m_Serial;
-
     template<typename T, size_t N>
     void read(T (&data)[N])
     {
@@ -51,6 +45,11 @@ private:
         m_Serial.write(data);
     }
 
+    //----------------------------------------------------------------------------
+    // Private members
+    //----------------------------------------------------------------------------
+    const bool m_AlternativeWiring;
+    SerialInterface m_Serial;
 }; // Mecanum
 } // Omni2D
 } // Robots

--- a/include/robots/omni2d/mecanum_pca_9685.h
+++ b/include/robots/omni2d/mecanum_pca_9685.h
@@ -18,8 +18,7 @@ namespace Omni2D {
 //----------------------------------------------------------------------------
 // BoBRobotics::Robots::Omni2D::MecanumPCA9685
 //----------------------------------------------------------------------------
-class MecanumPCA9685
-  : public Omni2DBase<MecanumPCA9685>
+class MecanumPCA9685 : public Omni2DBase<MecanumPCA9685>
 {
     friend Omni2DBase<MecanumPCA9685>;
 public:

--- a/include/robots/omni2d/mecanum_pca_9685.h
+++ b/include/robots/omni2d/mecanum_pca_9685.h
@@ -21,14 +21,16 @@ namespace Omni2D {
 class MecanumPCA9685
   : public Omni2DBase<MecanumPCA9685>
 {
+    friend Omni2DBase<MecanumPCA9685>;
 public:
     MecanumPCA9685(int slaveAddress = 0x40, const char *path = I2C_DEVICE_DEFAULT);
     ~MecanumPCA9685();
 
-    void omni2D(float forward, float sideways, float turn);
-
     //! Drive robot using individual motor speeds - all range from -1 to 1
     void driveMotors(float m1, float m2, float m3, float m4);
+
+protected:
+    void omni2DInternal(float forward, float sideways, float turn);
 
 private:
     //------------------------------------------------------------------------

--- a/include/robots/omni2d/omni2d_base.h
+++ b/include/robots/omni2d/omni2d_base.h
@@ -11,7 +11,9 @@ template<class Derived>
 class Omni2DBase
 {
 protected:
-    Omni2DBase<Derived>() = default;
+    Omni2DBase()
+    :   m_Forward(0.0f), m_Sideways(0.0f), m_Turn(0.0f)
+    {}
 
 public:
     void moveForward(float speed)
@@ -30,12 +32,23 @@ public:
         omni2D(0.f, 0.f, 0.f);
     }
 
+    float getForward() const{ return m_Forward; }
+    float getSideways() const{ return m_Sideways; }
+    float getTurn() const{ return m_Turn; }
+
 private:
     void omni2D(float forward, float sideways, float turn)
     {
         auto *derived = static_cast<Derived *>(this);
+        m_Forward = forward;
+        m_Sideways = sideways;
+        m_Turn = turn;
         derived->omni2D(forward, sideways, turn);
     }
+
+    float m_Forward;
+    float m_Sideways;
+    float m_Turn;
 
 }; // Omni2D
 } // Omni2D

--- a/include/robots/omni2d/omni2d_base.h
+++ b/include/robots/omni2d/omni2d_base.h
@@ -10,11 +10,6 @@ namespace Omni2D {
 template<class Derived>
 class Omni2DBase
 {
-protected:
-    Omni2DBase()
-    :   m_Forward(0.0f), m_Sideways(0.0f), m_Turn(0.0f)
-    {}
-
 public:
     void moveForward(float speed)
     {
@@ -30,6 +25,16 @@ public:
     void stopMoving()
     {
         omni2D(0.f, 0.f, 0.f);
+    }
+
+    void omni2D(float forward, float sideways, float turn)
+    {
+        m_Forward = forward;
+        m_Sideways = sideways;
+        m_Turn = turn;
+
+        auto *derived = static_cast<Derived *>(this);
+        derived->omni2DInternal(forward, sideways, turn);
     }
 
     float getForward() const{ return m_Forward; }
@@ -48,16 +53,12 @@ public:
         return getTurn();
     }
 
-private:
-    void omni2D(float forward, float sideways, float turn)
-    {
-        auto *derived = static_cast<Derived *>(this);
-        m_Forward = forward;
-        m_Sideways = sideways;
-        m_Turn = turn;
-        derived->omni2D(forward, sideways, turn);
-    }
+protected:
+    Omni2DBase()
+    :   m_Forward(0.0f), m_Sideways(0.0f), m_Turn(0.0f)
+    {}
 
+private:
     float m_Forward;
     float m_Sideways;
     float m_Turn;

--- a/include/robots/omni2d/omni2d_base.h
+++ b/include/robots/omni2d/omni2d_base.h
@@ -36,6 +36,18 @@ public:
     float getSideways() const{ return m_Sideways; }
     float getTurn() const{ return m_Turn; }
 
+    //! Get forward movement speed
+    float getForwardSpeed() const
+    {
+        return getForward();
+    }
+
+    //! Get turning speed
+    float getTurnSpeed() const
+    {
+        return getTurn();
+    }
+
 private:
     void omni2D(float forward, float sideways, float turn)
     {

--- a/include/robots/omni2d/tank_adaptor.h
+++ b/include/robots/omni2d/tank_adaptor.h
@@ -7,21 +7,21 @@ namespace BoBRobotics {
 namespace Robots {
 namespace Omni2D {
 template<class Omni2DType>
-class TankAdaptor
-  : public Tank::TankBase<TankAdaptor<Omni2DType>>
+class TankAdaptor : public Tank::TankBase<TankAdaptor<Omni2DType>>
 {
+    friend Tank::TankBase<TankAdaptor<Omni2DType>>
 public:
     TankAdaptor(Omni2DType &omni)
       : m_Omni{ omni }
     {}
 
+private:
     //! Implement tank controls in terms of omni
-    void tank(float left, float right)
+    void tankInternal(float left, float right)
     {
         m_Omni.omni2D((left + right) / 2.0f, 0.0f, (left - right) / 2.0f);
     }
 
-private:
     Omni2DType &m_Omni;
 }; // TankAdaptor
 } // Omni2D

--- a/include/robots/tank/atv.h
+++ b/include/robots/tank/atv.h
@@ -28,8 +28,6 @@ public:
     //----------------------------------------------------------------------------
     ~ATV();
 
-    void tank(float left, float right);
-
     static constexpr auto getMaximumSpeed()
     {
         return units::velocity::meters_per_second_t{ 0.11 };
@@ -47,6 +45,8 @@ public:
     RoboClaw &getRearController(){ return m_RearController; }
 
 private:
+    void tankInternal(float left, float right);
+
     //----------------------------------------------------------------------------
     // Members
     //----------------------------------------------------------------------------

--- a/include/robots/tank/atv.h
+++ b/include/robots/tank/atv.h
@@ -15,9 +15,9 @@ namespace Tank {
 // BoBRobotics::Robots::Tank::ATV
 //----------------------------------------------------------------------------
 //! An interface for large wheeled, all-terrain robot with two RoboClaw motor controllers
-class ATV
-  : public TankBase<ATV>
+class ATV : public TankBase<ATV>
 {
+    friend TankBase<ATV>;
 public:
     ATV(const char *frontPath = "//dev/serial/by-id/usb-Basicmicro_Inc._USB_Roboclaw_2x15A_10-if00",
         const char *rearPath = "/dev/serial/by-id/usb-Basicmicro_Inc._USB_Roboclaw_2x15A_20-if00",

--- a/include/robots/tank/dummy_tank.h
+++ b/include/robots/tank/dummy_tank.h
@@ -17,11 +17,6 @@ class DummyTank
   : public TankBase<DummyTank>
 {
 public:
-    static void tank(float left, float right)
-    {
-        LOGV << "Driving: " << left << ", " << right;
-    }
-
     static constexpr auto getRobotWidth()
     {
         return units::length::meter_t{ 1 };
@@ -30,6 +25,11 @@ public:
     static constexpr auto getMaximumSpeed()
     {
         return units::velocity::meters_per_second_t{ 1 };
+    }
+private:
+    static void tankInternal(float left, float right)
+    {
+        LOGV << "Driving: " << left << ", " << right;
     }
 }; // DummyTank
 } // Tank

--- a/include/robots/tank/dummy_tank.h
+++ b/include/robots/tank/dummy_tank.h
@@ -13,9 +13,9 @@ namespace Tank {
 // BoBRobotics::Robots::Tank::DummyTank
 //----------------------------------------------------------------------------
 //! A tank interface which just prints out commands (for debugging)
-class DummyTank
-  : public TankBase<DummyTank>
+class DummyTank : public TankBase<DummyTank>
 {
+    friend TankBase<DummyTank>;
 public:
     static constexpr auto getRobotWidth()
     {

--- a/include/robots/tank/net/sink.h
+++ b/include/robots/tank/net/sink.h
@@ -21,10 +21,11 @@ namespace Net {
 //----------------------------------------------------------------------------
 //! An interface for transmitting tank steering commands over the network
 template<class ConnectionType = BoBRobotics::Net::Connection &>
-class SinkBase
-  : public TankBase<SinkBase<ConnectionType>>
+class SinkBase : public TankBase<SinkBase<ConnectionType>>
 {
 private:
+    friend TankBase<SinkBase<ConnectionType>>;
+
     using millimeter_t = units::length::millimeter_t;
     using meters_per_second_t = units::velocity::meters_per_second_t;
     using radians_per_second_t = units::angular_velocity::radians_per_second_t;
@@ -63,9 +64,6 @@ public:
 
     ~SinkBase();
 
-    //! Motor command: send TNK command over TCP
-    void tank(float left, float right);
-
     millimeter_t getRobotWidth() const;
 
     meters_per_second_t getMaximumSpeed() const;
@@ -76,6 +74,10 @@ public:
     {
         return m_Connection;
     }
+
+protected:
+    //! Motor command: send TNK command over TCP
+    void tankInternal(float left, float right);
 
 }; // SinkBase
 

--- a/include/robots/tank/norbot.h
+++ b/include/robots/tank/norbot.h
@@ -26,8 +26,6 @@ public:
     //----------------------------------------------------------------------------
     ~Norbot();
 
-    void tank(float left, float right);
-
     static constexpr auto getMaximumSpeed()
     {
         return units::velocity::meters_per_second_t{ 0.11 };
@@ -40,6 +38,8 @@ public:
 
 private:
     I2CInterface m_I2C;
+
+    void tankInternal(float left, float right);
 
     template<typename T, size_t N>
     void read(T (&data)[N])

--- a/include/robots/tank/norbot.h
+++ b/include/robots/tank/norbot.h
@@ -15,9 +15,9 @@ namespace Tank {
 // BoBRobotics::Robots::Tank::Norbot
 //----------------------------------------------------------------------------
 //! An interface for wheeled, Arduino-based robots developed at the University of Sussex
-class Norbot
-  : public TankBase<Norbot>
+class Norbot : public TankBase<Norbot>
 {
+    friend TankBase<Norbot>;
 public:
     Norbot(const char *path = I2C_DEVICE_DEFAULT, int slaveAddress = 0x29);
 

--- a/include/robots/tank/simulated_tank.h
+++ b/include/robots/tank/simulated_tank.h
@@ -17,9 +17,9 @@ using namespace units::literals;
 
 template<typename LengthUnit = units::length::millimeter_t,
          typename AngleUnit = units::angle::degree_t>
-class SimulatedTank
-  : public TankBase<SimulatedTank<LengthUnit, AngleUnit>>
+class SimulatedTank : public TankBase<SimulatedTank<LengthUnit, AngleUnit>>
 {
+    friend TankBase<SimulatedTank<LengthUnit, AngleUnit>>;
     using millimeter_t = units::length::millimeter_t;
     using meters_per_second_t = units::velocity::meters_per_second_t;
 
@@ -57,7 +57,8 @@ public:
         return true;
     }
 
-    void tank(float left, float right)
+protected:
+    void tankInternal(float left, float right)
     {
         updatePose();
         BOB_ASSERT(left >= -1.f && left <= 1.f);

--- a/include/robots/tank/slowed_tank.h
+++ b/include/robots/tank/slowed_tank.h
@@ -8,19 +8,14 @@ namespace BoBRobotics {
 namespace Robots {
 namespace Tank {
 template<class TankType>
-class SlowedTank
-  : public TankBase<SlowedTank<TankType>>
+class SlowedTank : public TankBase<SlowedTank<TankType>>
 {
+    friend TankBase<SlowedTank<TankType>>;
 public:
     template<class... Ts>
     SlowedTank(Ts&&... args)
       : m_Tank(std::forward<Ts>(args)...)
     {}
-
-    void tank(float left, float right)
-    {
-        m_Tank.tank(left * m_MaximumSpeed, right * m_MaximumSpeed);
-    }
 
     void setMaximumSpeedProportion(float speed)
     {
@@ -43,6 +38,11 @@ public:
         return m_Tank.getRobotWidth();
     }
 
+protected:
+    void tankInternal(float left, float right)
+    {
+        m_Tank.tank(left * m_MaximumSpeed, right * m_MaximumSpeed);
+    }
 private:
     TankType m_Tank;
     float m_MaximumSpeed = 1.f;

--- a/include/robots/tank/tank_base.h
+++ b/include/robots/tank/tank_base.h
@@ -80,8 +80,23 @@ public:
         return radians_per_second_t{ (getMaximumSpeed() * 2 / getRobotWidth()).value() };
     }
 
+    //! Get low-level left motor speed
     float getLeft() const{ return m_Left; }
+
+    //! Get low-level right motor speed
     float getRight() const{ return m_Right; }
+
+    //! Get forward movement speed
+    float getForwardSpeed() const
+    {
+        return (getLeft() + getRight()) * 0.5f;
+    }
+
+    //! Get turning speed
+    float getTurnSpeed() const
+    {
+        return (getLeft() - getRight()) * 0.5f;
+    }
 
 protected:
     TankBase()

--- a/include/robots/tank/tank_base.h
+++ b/include/robots/tank/tank_base.h
@@ -74,6 +74,13 @@ public:
         }
     }
 
+    void tank(float left, float right)
+    {
+        m_Left = left;
+        m_Right = right;
+        static_cast<Derived *>(this)->tankInternal(left, right);
+    }
+
     radians_per_second_t getMaximumTurnSpeed() const
     {
         // max turn speed = v_max / r
@@ -104,13 +111,6 @@ protected:
     {}
 
 private:
-    void tank(float left, float right)
-    {
-        m_Left = left;
-        m_Right = right;
-        static_cast<Derived *>(this)->tank(left, right);
-    }
-
     meter_t getRobotWidth() const
     {
         return static_cast<const Derived *>(this)->getRobotWidth();

--- a/include/robots/tank/tank_base.h
+++ b/include/robots/tank/tank_base.h
@@ -80,9 +80,19 @@ public:
         return radians_per_second_t{ (getMaximumSpeed() * 2 / getRobotWidth()).value() };
     }
 
+    float getLeft() const{ return m_Left; }
+    float getRight() const{ return m_Right; }
+
+protected:
+    TankBase()
+    :   m_Left(0.0f), m_Right(0.0f)
+    {}
+
 private:
     void tank(float left, float right)
     {
+        m_Left = left;
+        m_Right = right;
         static_cast<Derived *>(this)->tank(left, right);
     }
 
@@ -95,6 +105,9 @@ private:
     {
         return static_cast<const Derived *>(this)->getMaximumSpeed();
     }
+
+    float m_Left;
+    float m_Right;
 
 }; // TankBase
 } // Tank

--- a/src/robots/omni2d/mecanum.cc
+++ b/src/robots/omni2d/mecanum.cc
@@ -49,21 +49,6 @@ Mecanum::~Mecanum()
 //----------------------------------------------------------------------------
 // Omni2DBase virtuals
 //----------------------------------------------------------------------------
-void
-Mecanum::omni2D(float forward, float sideways, float turn)
-{
-    // resolve to motor speeds
-    const float m1 = m_AlternativeWiring ? (-sideways + forward - turn) : (+sideways - forward - turn);
-    const float m2 = +sideways + forward + turn;
-    const float m3 = m_AlternativeWiring ? (+sideways + forward - turn) : (-sideways + forward - turn);
-    const float m4 = m_AlternativeWiring ? (-sideways + forward + turn) : (-sideways - forward + turn);
-
-    // Cap before passing to driveMotors as valid forward, sideways and
-    // turn values can still result in invalid m1, m2, m3 and m4
-    const auto cap = [](float val) { return std::min(1.0f, std::max(val, -1.0f)); };
-    driveMotors(cap(m1), cap(m2), cap(m3), cap(m4));
-}
-//----------------------------------------------------------------------------
 void Mecanum::driveMotors(float m1, float m2, float m3, float m4)
 {
     BOB_ASSERT(m1 >= -1.0f && m1 <= 1.0f);
@@ -77,7 +62,21 @@ void Mecanum::driveMotors(float m1, float m2, float m3, float m4)
     // Send buffer
     write(buffer);
 }
+//----------------------------------------------------------------------------
+void
+Mecanum::omni2DInternal(float forward, float sideways, float turn)
+{
+    // resolve to motor speeds
+    const float m1 = m_AlternativeWiring ? (-sideways + forward - turn) : (+sideways - forward - turn);
+    const float m2 = +sideways + forward + turn;
+    const float m3 = m_AlternativeWiring ? (+sideways + forward - turn) : (-sideways + forward - turn);
+    const float m4 = m_AlternativeWiring ? (-sideways + forward + turn) : (-sideways - forward + turn);
 
+    // Cap before passing to driveMotors as valid forward, sideways and
+    // turn values can still result in invalid m1, m2, m3 and m4
+    const auto cap = [](float val) { return std::min(1.0f, std::max(val, -1.0f)); };
+    driveMotors(cap(m1), cap(m2), cap(m3), cap(m4));
+}
 } // Omni2D
 } // Robots
 } // BoBRobotics

--- a/src/robots/omni2d/mecanum_pca_9685.cc
+++ b/src/robots/omni2d/mecanum_pca_9685.cc
@@ -34,25 +34,6 @@ MecanumPCA9685::~MecanumPCA9685()
 //----------------------------------------------------------------------------
 // Omni2D virtuals
 //----------------------------------------------------------------------------
-void
-MecanumPCA9685::omni2D(float forward, float sideways, float turn)
-{
-    BOB_ASSERT(forward >= -1.0f && forward <= 1.0f);
-    BOB_ASSERT(sideways >= -1.0f && sideways <= 1.0f);
-    BOB_ASSERT(turn >= -1.0f && turn <= 1.0f);
-
-    // resolve to motor speeds
-    const float m1 = -sideways + forward - turn;
-    const float m2 = +sideways + forward + turn;
-    const float m3 = +sideways + forward - turn;
-    const float m4 = -sideways + forward + turn;
-
-    // Cap before passing to driveMotors as valid forward, sideways and
-    // turn values can still result in invalid m1, m2, m3 and m4
-    const auto cap = [](float val) { return std::min(1.0f, std::max(val, -1.0f)); };
-    driveMotors(cap(m1), cap(m2), cap(m3), cap(m4));
-}
-//----------------------------------------------------------------------------
 void MecanumPCA9685::driveMotors(float m1, float m2, float m3, float m4)
 {
     setMotorThrottle(Motor::MOTOR_1, m1);
@@ -82,7 +63,25 @@ void MecanumPCA9685::setMotorThrottle(Motor motor, float throttle)
         m_PCA9685.setDutyCycle(motorChannels[motor][MOTOR_CHANNEL_NEGATIVE], 0.0f);
     }
 }
+//----------------------------------------------------------------------------
+void
+MecanumPCA9685::omni2DInternal(float forward, float sideways, float turn)
+{
+    BOB_ASSERT(forward >= -1.0f && forward <= 1.0f);
+    BOB_ASSERT(sideways >= -1.0f && sideways <= 1.0f);
+    BOB_ASSERT(turn >= -1.0f && turn <= 1.0f);
 
+    // resolve to motor speeds
+    const float m1 = -sideways + forward - turn;
+    const float m2 = +sideways + forward + turn;
+    const float m3 = +sideways + forward - turn;
+    const float m4 = -sideways + forward + turn;
+
+    // Cap before passing to driveMotors as valid forward, sideways and
+    // turn values can still result in invalid m1, m2, m3 and m4
+    const auto cap = [](float val) { return std::min(1.0f, std::max(val, -1.0f)); };
+    driveMotors(cap(m1), cap(m2), cap(m3), cap(m4));
+}
 } // Omni2D
 } // Robots
 } // BoBRobotics

--- a/src/robots/tank/atv.cc
+++ b/src/robots/tank/atv.cc
@@ -22,7 +22,7 @@ ATV::~ATV()
     stopMoving();
 }
 
-void ATV::tank(float left, float right)
+void ATV::tankInternal(float left, float right)
 {
     m_FrontController.setMotor1Speed(-left);
     m_FrontController.setMotor2Speed(right);

--- a/src/robots/tank/norbot.cc
+++ b/src/robots/tank/norbot.cc
@@ -39,7 +39,7 @@ Norbot::~Norbot()
     stopMoving();
 }
 
-void Norbot::tank(float left, float right)
+void Norbot::tankInternal(float left, float right)
 {
     // Convert standard (-1,1) values to bytes in order to send to I2C slave
     uint8_t buffer[2] = { floatToI2C(left), floatToI2C(right) };


### PR DESCRIPTION
In order to implement robot-agnostic code to e.g. determine if the robot is moving or not, we want access to forward speed and turn speed. This should be pretty simple:

- Track the raw motor values in ``Omni2DBase`` and ``TankBase`` in the ``tank()`` and ``omni2D()`` methods
- Provide functionality to turn this into standard form of forward and turn speed (for omni this is trivial!) in same way that ``moveForward``, ``turnOnTheSpot`` turn standard commands into robot-specific ones

Some of this functionality existed in the past but was removed (@alexdewar any idea why? Tracking raw motor values  seems useful and exactly the type of thing the robot abstraction should provide) and, additionally, switching from a standard class hierarchy of robot classes to curiously-recurring template pattern makes it irritating as I have needed to liberally scatter ``friend`` declarations around (again, can't really remember why this change was made so worried I'm missing something here @alexdewar).