### PR TITLE
Fixed typo in algos and corrected name of dependency

### DIFF
--- a/python/antworld/pyproject.toml
+++ b/python/antworld/pyproject.toml
@@ -1,2 +1,2 @@
 [build-system]
-requires = ["setuptools", "wheel", "scikit-build", "cmake", "cv2", "numpy"]
+requires = ["setuptools", "wheel", "scikit-build", "cmake", "opencv-python", "numpy"]

--- a/python/navigation/src/algos.cc
+++ b/python/navigation/src/algos.cc
@@ -395,7 +395,6 @@ addAlgorithmClasses(py::module &m)
                         return PyAlgoWrapper<InfoMaxType>{
                             state[0].cast<cv::Size>(),
                             state[1].cast<float>(),
-                            state[2].cast<float>(),
                             state[3].cast<Normalisation>(),
                             nullopt,
                             state[4].cast<InfoMaxType::MatrixType>()


### PR DESCRIPTION
I'm afraid I still can't actually get this to work but these two issues definitely didn't help! @alexdewar when I build the old fashioned way e.g.
```
python antworld/setup.py develop
```
from ``python/`` it _appears_ to work but it looks like the egg-link is screwed and Python can't figure out how to map the ``bob_robotics`` python module to the  ``python`` directory and thus the two packages within  (I'm not really sure how the bob_robotics "namespace" thing is supposed to work really - I've never encountered a python package that works like this). The modern way:
```
pip install --editable antworld/
```
Fails with ``ERROR: Could not install packages due to an OSError: [Errno 2] No such file or directory: '/its/home/jk421/bob_robotics/python/bob_robotics/antworld'`` which also suggest the installation is doing something really screwy. How **ARE** you supposed to install this thing? Clearly this is related to #353 but, unless you've got a fix knocking around, the only fix I would be confident with would be to turn this into a single standard ``bob_robotics`` package containing ``navigation`` and ``antworld``