### PR TITLE
Support resetting of BN055 IMU

### DIFF
--- a/examples/bn055/bn055.cc
+++ b/examples/bn055/bn055.cc
@@ -11,9 +11,32 @@ int bobMain(int, char **)
 {
     BN055 imu;
 
+    bool failed = false;
     while(true) {
-        const auto euler = imu.getEulerAngles();
-        LOG_INFO << euler[0];
+        try {
+            // Attempt to read IMU
+            const auto euler = imu.getEulerAngles();
+
+            // If we had previously failed (but this time it has succeeded because exception wasn't thrown)
+            if(failed) {
+                LOGE << "Attempting IMU reset";
+                imu.setup();
+                failed = false;
+            }
+            // Otherwise, show IMU output
+            else {
+                LOG_INFO << euler[0];
+            }
+        } catch (std::exception &e) {
+            // If this is the first time reading has failed, show error
+            if(!failed) {
+                LOGE << "Could not read from IMU: " << e.what();
+            }
+
+            // Set fail flag
+            failed = true;
+        }
+
     }
     return EXIT_SUCCESS;
 }

--- a/include/common/bn055_imu.h
+++ b/include/common/bn055_imu.h
@@ -263,6 +263,8 @@ public:
     //----------------------------------------------------------------------------
     // Public API
     //----------------------------------------------------------------------------
+    void setup(OperationMode mode = OperationMode::NDOF);
+    
     Eigen::Quaternionf getQuaternion();
     
     Eigen::Vector3f getVector(VectorType vectorType = VectorType::EULER);

--- a/src/common/bn055_imu.cc
+++ b/src/common/bn055_imu.cc
@@ -18,8 +18,6 @@ constexpr uint8_t BN055::imuID;
 //----------------------------------------------------------------------------
 BN055::BN055(OperationMode mode, const char *path, int slaveAddress)
 {
-    using namespace std::chrono_literals;
-
     // Setup I2C device
     m_IMU.setup(path, slaveAddress);
 
@@ -28,6 +26,14 @@ BN055::BN055(OperationMode mode, const char *path, int slaveAddress)
     if(chipID != imuID) {
         throw std::runtime_error("Incorrect chip id at slave address:" + std::to_string(slaveAddress));
     }
+
+    // Configure into desired mode
+    setup(mode);
+}
+//----------------------------------------------------------------------------
+void BN055::setup(OperationMode mode)
+{
+    using namespace std::chrono_literals;
 
     LOGD << "Switching mode";
     // Switch to config mode (just in case since this is the default)


### PR DESCRIPTION
These devices startup e.g. if power is lost in configuration mode where they don't read from any axes. I have moved the logic to reset the mode from the BN055 constructor into a method which you can call from your exception handler. If this makes sense, I will incorporate it into the data collection app.