### PR TITLE
New options for antworld

### DIFF
--- a/include/antworld/world.h
+++ b/include/antworld/world.h
@@ -50,8 +50,11 @@ public:
     // Public API
     //------------------------------------------------------------------------
     void render() const;
-    void load(const filesystem::path &filename, const GLfloat (&worldColour)[3], const GLfloat (&groundColour)[3]);
-    void loadObj(const filesystem::path &objFilename, float scale = 1.0f, int maxTextureSize = -1, GLint textureFormat = GL_RGB);
+    void load(const filesystem::path &filename, const GLfloat (&worldColour)[3],
+              const GLfloat (&groundColour)[3], bool clear = true);
+    void loadObj(const filesystem::path &objFilename, float scale = 1.0f,
+                 int maxTextureSize = -1, GLint textureFormat = GL_RGB, 
+                 bool clear = true);
 
     const Vector3<meter_t> &getMinBound()
     {

--- a/python/antworld/src/antworld.cc
+++ b/python/antworld/src/antworld.cc
@@ -226,31 +226,21 @@ Agent_set_attitude(AgentObject *self, PyObject *args)
 DLL_EXPORT PyObject *
 Agent_set_fog(AgentObject *self, PyObject *args, PyObject *kwargs)
 {
-    char *mode;
-    if (!PyArg_ParseTuple(args, "s", &mode)) {
+    static char *kwlist[] = {"mode", "colour", "start", "end", "density", NULL};
+    
+    // Read renderer settings from kwargs
+    char *mode = nullptr;
+    PyObject *colour = nullptr;
+    double start = 0.0;
+    double end = 0.0;
+    double density = 1.0;
+    if (!PyArg_ParseTupleAndKeywords(args, kwargs, "s|O!ddd", kwlist, 
+                                     &mode, &colour, &start, &end, &density)) 
+    {
         return nullptr;
     }
     
-    // If fog is disabled, turn it off
-    if(strcmp(mode, "disabled")) {
-        glDisable(GL_FOG);
-    }
-    // Otherwise
-    else {
-        // Enable fog
-        glEnable(GL_FOG);
-        
-        // If linear, 
-        if(strcmp(mode, "linear")) {
-        }
-        else if(strcmp(mode, "exp")) {
-        }
-        else if(strcmp(mode, "exp2")) {
-        }
-        else {
-            return nullptr;
-        }
-    }
+    std::cout << "mode:" << mode << ":" << start << "," << end << "," << density <<std::endl;
     
     Py_RETURN_NONE;
 }

--- a/python/antworld/src/antworld.cc
+++ b/python/antworld/src/antworld.cc
@@ -233,10 +233,10 @@ Agent_set_fog(AgentObject *self, PyObject *args, PyObject *kwargs)
     // Read renderer settings from kwargs
     char *mode = nullptr;
     PyObject *colour = nullptr;
-    double start = 0.0;
-    double end = 0.0;
-    double density = 1.0;
-    if (!PyArg_ParseTupleAndKeywords(args, kwargs, "s|Oddd", kwlist, 
+    GLfloat start = 0.0f;
+    GLfloat end = 0.0f;
+    GLfloat density = 1.0f;
+    if (!PyArg_ParseTupleAndKeywords(args, kwargs, "s|Offf", kwlist, 
                                      &mode, &colour, &start, &end, &density)) 
     {
         return nullptr;
@@ -245,8 +245,8 @@ Agent_set_fog(AgentObject *self, PyObject *args, PyObject *kwargs)
     // If colour was passed
     if(colour) {
         // Parse colour 
-        GLfloat colourArray[4];
-        if (!PyArg_ParseTuple(colour, "ffff", &colourArray[0], &colourArray[1], 
+        GLfloat colourArray[4]{0.75f, 0.75f, 0.75f, 1.0f};
+        if (!PyArg_ParseTuple(colour, "fff|f", &colourArray[0], &colourArray[1], 
             &colourArray[2], &colourArray[3])) 
         {
             return nullptr;
@@ -288,6 +288,24 @@ Agent_set_fog(AgentObject *self, PyObject *args, PyObject *kwargs)
 }
 
 DLL_EXPORT PyObject *
+Agent_set_clear_colour(AgentObject *self, PyObject *args)
+{
+    // Parse colour 
+    GLfloat r = 0.75f;
+    GLfloat g = 0.75f;
+    GLfloat b = 0.75f;
+    GLfloat a = 1.0f;
+    if(!PyArg_ParseTuple(args, "fff|f", &r, &g, &b, &a)) 
+    {
+        return nullptr;
+    }
+
+    glClearColor(r, g, b, a);
+    
+    Py_RETURN_NONE;
+}
+
+DLL_EXPORT PyObject *
 Agent_display(AgentObject *self, PyObject *)
 {
     self->members->agent.display();
@@ -308,6 +326,8 @@ static PyMethodDef Agent_methods[] = {
       "Set the agent's current attitude" },
     { "set_fog", (PyCFunction) Agent_set_fog, METH_VARARGS | METH_KEYWORDS,
       "Configure fog settings for rendering" },
+    { "set_clear_colour", (PyCFunction) Agent_set_clear_colour, METH_VARARGS,
+      "Configure clear colour settings for rendering" },
     { "display", (PyCFunction) Agent_display, METH_NOARGS,
       "Render to the current window (you don't need to call this explicitly if calling read_frame)" },
     {}

--- a/python/antworld/src/antworld.cc
+++ b/python/antworld/src/antworld.cc
@@ -96,7 +96,8 @@ DLL_EXPORT PyObject *
 Agent_load_world(AgentObject *self, PyObject *args)
 {
     char *filepath_c;
-    if (!PyArg_ParseTuple(args, "s", &filepath_c)) {
+    int clear = 1;
+    if (!PyArg_ParseTuple(args, "s|p", &filepath_c, &clear)) {
         return nullptr;
     }
 
@@ -106,9 +107,10 @@ Agent_load_world(AgentObject *self, PyObject *args)
         const auto ext = filepath.extension();
         if (ext == "bin") {
             // Load with default world and ground colours
-            world.load(filepath, { 0.0f, 1.0f, 0.0f }, { 0.898f, 0.718f, 0.353f });
+            world.load(filepath, { 0.0f, 1.0f, 0.0f },
+                       { 0.898f, 0.718f, 0.353f }, clear);
         } else if (ext == "obj") {
-            world.loadObj(filepath);
+            world.loadObj(filepath, 1.0f, -1, GL_RGB, clear);
         } else {
             throw std::runtime_error{ "Unknown file type" };
         }

--- a/python/antworld/src/antworld.cc
+++ b/python/antworld/src/antworld.cc
@@ -227,21 +227,61 @@ DLL_EXPORT PyObject *
 Agent_set_fog(AgentObject *self, PyObject *args, PyObject *kwargs)
 {
     static char *kwlist[] = {"mode", "colour", "start", "end", "density", NULL};
-    
+
     // Read renderer settings from kwargs
     char *mode = nullptr;
     PyObject *colour = nullptr;
     double start = 0.0;
     double end = 0.0;
     double density = 1.0;
-    if (!PyArg_ParseTupleAndKeywords(args, kwargs, "s|O!ddd", kwlist, 
+    if (!PyArg_ParseTupleAndKeywords(args, kwargs, "s|Oddd", kwlist, 
                                      &mode, &colour, &start, &end, &density)) 
     {
         return nullptr;
     }
+
+    // If colour was passed
+    if(colour) {
+        // Parse colour 
+        GLfloat colourArray[4];
+        if (!PyArg_ParseTuple(colour, "ffff", &colourArray[0], &colourArray[1], 
+            &colourArray[2], &colourArray[3])) 
+        {
+            return nullptr;
+        }
+        
+        // Set fog colour
+        glFogfv (GL_FOG_COLOR, colourArray);
+    }
+
+    // Set fog start, end and density
+    glFogf(GL_FOG_START, start);
+    glFogf(GL_FOG_END, end);
+    glFogf(GL_FOG_DENSITY, density);
     
-    std::cout << "mode:" << mode << ":" << start << "," << end << "," << density <<std::endl;
-    
+    // If fog is disabled, turn it off
+    if(strcmp(mode, "disabled") == 0) {
+        glDisable(GL_FOG);
+    }
+    // Otherwise
+    else {
+        // Enable
+        glEnable(GL_FOG);
+
+        // Convert mode string to GL enumeration
+        if(strcmp(mode, "linear") == 0) {
+            glFogi(GL_FOG_MODE, GL_LINEAR);
+        }
+        else if(strcmp(mode, "exp") == 0) {
+            glFogi(GL_FOG_MODE, GL_EXP);
+        }
+        else if(strcmp(mode, "exp2") == 0) {
+            glFogi(GL_FOG_MODE, GL_EXP2);
+        }
+        else {
+            return nullptr;
+        }
+    }
     Py_RETURN_NONE;
 }
 

--- a/python/examples/test_antworld.py
+++ b/python/examples/test_antworld.py
@@ -10,7 +10,7 @@ from bob_robotics import antworld
 worldpath = antworld.bob_robotics_path + "/resources/antworld/seville_vegetation_downsampled.obj"
 z = 1.5 # m (for some reason the ground is at ~1.5m for this world)
 
-agent = antworld.Agent(720, 150, cubemap_size=16)
+agent = antworld.Agent(720, 150, cubemap_size=512, near_clip=0.1)
 (xlim, ylim, zlim) = agent.load_world(worldpath)
 xstart = xlim[0] + (xlim[1] - xlim[0]) / 2.0
 y = ylim[0] + (ylim[1] - ylim[0]) / 2.0
@@ -18,13 +18,15 @@ y = ylim[0] + (ylim[1] - ylim[0]) / 2.0
 print("starting at (%f, %f, %f)" % (xstart, y, z))
 
 fogit = [{"mode": "disabled"},
-         {"mode": "linear", "start": 10.0, "end": 100.0},
-         {"mode": "exp", "density": 1.0}]
+         {"mode": "linear", "start": 0.0, "end": 100.0, "colour": (0.75, 0.75, 0.75, 1.0)},
+         {"mode": "exp", "density": 1.0, "colour": (0.75, 0.75, 0.75, 1.0)},
+         {"mode": "exp", "density": 0.5, "colour": (0.75, 0.75, 0.75, 1.0)},
+         {"mode": "exp2", "density": 1.0, "colour": (0.75, 0.75, 0.75, 1.0)},
+         {"mode": "exp2", "density": 0.5, "colour": (0.75, 0.75, 0.75, 1.0)}]
 
 for x, f in enumerate(fogit):
-    print(x)
-    agent.set_position(x + xstart, y, z)
-    #agent.set_fog(**f)
+    agent.set_position(xstart + (x * 0.5), y, z)
+    agent.set_fog(**f)
     im = agent.read_frame()
     filename = "antworld%i.png" % x
     print("Saving image as %s..." % filename)

--- a/python/examples/test_antworld.py
+++ b/python/examples/test_antworld.py
@@ -10,15 +10,21 @@ from bob_robotics import antworld
 worldpath = antworld.bob_robotics_path + "/resources/antworld/seville_vegetation_downsampled.obj"
 z = 1.5 # m (for some reason the ground is at ~1.5m for this world)
 
-agent = antworld.Agent(720, 150)
+agent = antworld.Agent(720, 150, cubemap_size=16)
 (xlim, ylim, zlim) = agent.load_world(worldpath)
 xstart = xlim[0] + (xlim[1] - xlim[0]) / 2.0
 y = ylim[0] + (ylim[1] - ylim[0]) / 2.0
 
 print("starting at (%f, %f, %f)" % (xstart, y, z))
 
-for x in range(3):
+fogit = [{"mode": "disabled"},
+         {"mode": "linear", "start": 10.0, "end": 100.0},
+         {"mode": "exp", "density": 1.0}]
+
+for x, f in enumerate(fogit):
+    print(x)
     agent.set_position(x + xstart, y, z)
+    #agent.set_fog(**f)
     im = agent.read_frame()
     filename = "antworld%i.png" % x
     print("Saving image as %s..." % filename)

--- a/src/antworld/world.cc
+++ b/src/antworld/world.cc
@@ -446,7 +446,6 @@ void World::loadMaterials(const filesystem::path &basePath, const std::string &f
                           std::map<std::string, std::tuple<Texture*, Surface::Colour>> &materialNames)
 {
     // Open obj file
-    LOGE << (basePath / filename).str();
     std::ifstream mtlFile((basePath / filename).str());
     BOB_ASSERT(!mtlFile.fail());
     mtlFile.exceptions(std::ios::badbit);

--- a/src/antworld/world.cc
+++ b/src/antworld/world.cc
@@ -112,9 +112,7 @@ std::string readName(std::istringstream &lineStream)
     std::getline(lineStream, name);
     const size_t firstNonQuote = name.find_first_not_of('"');
     const size_t lastNonQuote = name.find_last_not_of('"');
-    name = name.substr(firstNonQuote, lastNonQuote - firstNonQuote + 1);
-
-    return name;
+    return name.substr(firstNonQuote, lastNonQuote - firstNonQuote + 1);
 }
 }
 

--- a/src/antworld/world.cc
+++ b/src/antworld/world.cc
@@ -99,6 +99,23 @@ void stripWindowsLineEnding(std::string &lineString)
         lineString.pop_back();
     }
 }
+//----------------------------------------------------------------------------
+std::string readName(std::istringstream &lineStream)
+{
+    // Skip any whitespace preceeding name
+    while(lineStream.peek() == ' ') {
+        lineStream.get();
+    }
+
+    // Treat remainder of line as name
+    std::string name;
+    std::getline(lineStream, name);
+    const size_t firstNonQuote = name.find_first_not_of('"');
+    const size_t lastNonQuote = name.find_last_not_of('"');
+    name = name.substr(firstNonQuote, lastNonQuote - firstNonQuote + 1);
+
+    return name;
+}
 }
 
 //----------------------------------------------------------------------------
@@ -109,12 +126,16 @@ namespace BoBRobotics
 namespace AntWorld
 {
 void World::load(const filesystem::path &filename, const GLfloat (&worldColour)[3],
-                 const GLfloat (&groundColour)[3])
+                 const GLfloat (&groundColour)[3], bool clear)
 {
     LOGI << "Loading " << filename << "...";
 
+    // Clear existing surfaces if required
+    if(clear) {
+        m_Surfaces.clear();
+    }
+
     // Create single surface
-    m_Surfaces.clear();
     m_Surfaces.emplace_back();
     auto &surface = m_Surfaces.back();
 
@@ -224,7 +245,8 @@ void World::load(const filesystem::path &filename, const GLfloat (&worldColour)[
     surface.unbind();
 }
 //----------------------------------------------------------------------------
-void World::loadObj(const filesystem::path &filename, float scale, int maxTextureSize, GLint textureFormat)
+void World::loadObj(const filesystem::path &filename, float scale,
+                    int maxTextureSize, GLint textureFormat, bool clear)
 {
     LOGI << "Loading " << filename << "...";
 
@@ -288,10 +310,8 @@ void World::loadObj(const filesystem::path &filename, float scale, int maxTextur
             // Read command from first token
             lineStream >> commandString;
             if(commandString == "mtllib") {
-                lineStream >> parameterString;
-
                 // Parse materials
-                loadMaterials(basePath, parameterString,
+                loadMaterials(basePath, readName(lineStream),
                               textureFormat, maxTextureSize,
                               materialNames);
             }
@@ -365,16 +385,19 @@ void World::loadObj(const filesystem::path &filename, float scale, int maxTextur
     }
 
     // Remove any existing surfaces
-    m_Surfaces.clear();
-
+    if(clear) {
+        m_Surfaces.clear();
+    }
+    
     // Allocate new materials array to match those found in obj
-    m_Surfaces.resize(objSurfaces.size());
+    m_Surfaces.reserve(m_Surfaces.size() + objSurfaces.size());
 
     // Loop through surfaces
-    for(unsigned int s = 0; s < objSurfaces.size(); s++) {
-        const auto &objSurface = objSurfaces[s];
-        auto &surface = m_Surfaces[s];
-
+    for(const auto &objSurface : objSurfaces) {
+        // Create surface
+        m_Surfaces.emplace_back();
+        auto &surface = m_Surfaces.back();
+        
         // Find corresponding material
         const auto mtl = materialNames.find(std::get<0>(objSurface));
 
@@ -425,6 +448,7 @@ void World::loadMaterials(const filesystem::path &basePath, const std::string &f
                           std::map<std::string, std::tuple<Texture*, Surface::Colour>> &materialNames)
 {
     // Open obj file
+    LOGE << (basePath / filename).str();
     std::ifstream mtlFile((basePath / filename).str());
     BOB_ASSERT(!mtlFile.fail());
     mtlFile.exceptions(std::ios::badbit);
@@ -480,17 +504,8 @@ void World::loadMaterials(const filesystem::path &basePath, const std::string &f
         else if(commandString == "map_Kd") {
             BOB_ASSERT(!currentMaterialName.empty());
 
-            // Skip any whitespace preceeding texture filename
-            while(lineStream.peek() == ' ') {
-                lineStream.get();
-            }
 
-            // Treat remainder of line as texture filename
-            std::string textureFilename;
-            std::getline(lineStream, textureFilename);
-            const size_t firstNonQuote = textureFilename.find_first_not_of('"');
-            const size_t lastNonQuote = textureFilename.find_last_not_of('"');
-            textureFilename = textureFilename.substr(firstNonQuote, lastNonQuote - firstNonQuote + 1);
+            std::string textureFilename = readName(lineStream);
 
             LOG_DEBUG << "\t\tTexture: '" << textureFilename << "'";
 


### PR DESCRIPTION
@thomasMisiek is exploring some exciting new stuff with the rothamsted dataset so I've added a few new features here:
* Exposed the ``cubemapSize``, ``nearClip``, ``farClip``, ``horizontalFOV``, ``verticalFOV`` ``AntWorld::Renderer`` constructor options - useful for higher quality rendering of more complex worlds
* Added fog control to the python wrapper - this is plain OpenGL so need for deeper integration - in a C++ application, you'd just call these directly
   * ``agent.set_fog("disabled")`` turns it off
   * ``agent.set_fog("linear", start=0, end=1000, "colour": (0.75, 0.75, 0.75))`` turns on the rubbishest form of grey fog
   * ``agent.set_fog("exp", density=1.0, "colour": (0.75, 0.75, 0.75))`` turns on a nicer sort of fog  like the screenshot
   * ``agent.set_fog("exp2", density=1.0, "colour": (0.75, 0.75, 0.75))`` turns on another nicer sort of fog
* Added clear colour control the python wrapper - again this is plain OpenGL so need for any deeper integration
  * ``agent.set_clear_colour(1.0, 0.0, 0.0)`` sets clear colour to red
* Added ``clear`` flag to determine whether ``World::load`` and ``World::loadObj`` clear out pre-existing surfaces or just add more
* Moved existing long-filename handling code out of ``World::loadMaterials`` into helper function to enable support for long material filenames

Exponential fog:
![antworld2](https://github.com/BrainsOnBoard/bob_robotics/assets/6793242/9a6eb66f-951b-4584-90d8-2fcaad6026cc)

Red clear colour:
![antworld0](https://github.com/BrainsOnBoard/bob_robotics/assets/6793242/06395a81-1651-495e-a8ad-96cc537f8069)
