### PR TITLE
Remote joystick

### DIFF
--- a/examples/joystick_net/CMakeLists.txt
+++ b/examples/joystick_net/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.10)
+project(joystick_net)
+include(../../cmake/BoBRobotics.cmake)
+
+find_package(BoBRobotics QUIET REQUIRED COMPONENTS hid hid/net)
+
+add_executable(joystick_net_polling joystick_net_polling.cc)
+target_link_libraries(joystick_net_polling PUBLIC ${BoBRobotics_LIBRARIES})

--- a/examples/joystick_net/joystick_net_polling.cc
+++ b/examples/joystick_net/joystick_net_polling.cc
@@ -1,0 +1,40 @@
+// BoB robotics includes
+#include "plog/Log.h"
+#include "hid/net/source.h"
+#include "net/server.h"
+
+// Standard C++ includes
+#include <chrono>
+#include <thread>
+
+using namespace BoBRobotics::HID;
+
+int bobMain(int, char **)
+{
+    // Listen for incoming connection on default port
+    BoBRobotics::Net::Server server;
+    auto connection = server.waitForConnection();
+
+    // Read motor commands from network
+    Net::Source js(*connection);
+
+    for (int i = 1; !js.isDown(JButton::B); i++) {
+        // read from joystick
+        js.update();
+
+        if (js.isDown(JButton::A)) {
+            LOGI << i << " | A is down";
+        }
+        if (js.isPressed(JButton::A)) {
+            LOGI << i << " | A has been pressed";
+        }
+        if (js.isReleased(JButton::A)) {
+            LOGI << i << " | A has been released";
+        }
+
+        // wait
+        std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    }
+
+    return EXIT_SUCCESS;
+}

--- a/include/hid/net/sink.h
+++ b/include/hid/net/sink.h
@@ -1,0 +1,33 @@
+#pragma once
+
+// BoB robotics includes
+#include "hid/joystick.h"
+
+// Forward declarations
+namespace BoBRobotics {
+namespace Net {
+    class Connection;
+}
+}
+
+namespace BoBRobotics {
+namespace HID {
+namespace Net {
+
+//----------------------------------------------------------------------------
+// BoBRobotics::HID::Net::Sink
+//----------------------------------------------------------------------------
+//! An interface for transmitting joystick commands over the network
+class Sink
+{
+public:
+    Sink(BoBRobotics::Net::Connection &connection, Joystick &joystick);
+
+private:
+    BoBRobotics::Net::Connection &m_Connection;
+}; // Source
+
+
+} // Net
+} // HID
+} // BoBRobotics

--- a/include/hid/net/sink.h
+++ b/include/hid/net/sink.h
@@ -24,6 +24,9 @@ public:
     Sink(BoBRobotics::Net::Connection &connection, Joystick &joystick);
 
 private:
+    //------------------------------------------------------------------------
+    // Members
+    //------------------------------------------------------------------------
     BoBRobotics::Net::Connection &m_Connection;
 }; // Source
 

--- a/include/hid/net/source.h
+++ b/include/hid/net/source.h
@@ -1,22 +1,68 @@
 #pragma once
 
 // BoB robotics includes
-#include "net/connection.h"
+#include "hid/joystick.h"
 
 // Standard C++ includes
-#include <sstream>
+#include <mutex>
+#include <vector>
+
+// Forward declarations
+namespace BoBRobotics {
+namespace Net {
+    class Connection;
+}
+}
 
 namespace BoBRobotics {
 namespace HID {
 namespace Net {
 
-class Source : public JoystickBase
+//----------------------------------------------------------------------------
+// BoBRobotics::HID::Net::Source
+//----------------------------------------------------------------------------
+//! A virtual joystick controlled over the network
+class Source : public JoystickBase<JAxis, JButton>
 {
 public:
-    Source(BoBRobotics::Net::Connection &connection)
+    Source(BoBRobotics::Net::Connection &connection);
+    virtual ~Source();
+
+    //------------------------------------------------------------------------
+    // JoystickBase virtuals
+    //------------------------------------------------------------------------
+    virtual bool updateState() override final;
 
 private:
+    //------------------------------------------------------------------------
+    // Event
+    //------------------------------------------------------------------------
+    //! Missing C++17 std::variant here...
+    struct Event
+    {
+        bool axisNotButton;
+        union
+        {
+            struct
+            {
+                JAxis axis;
+                float value;
+            } axis;
 
+            struct
+            {
+                JButton button;
+                bool pressed;
+            } button;
+        };
+    };
+
+    //------------------------------------------------------------------------
+    // Members
+    //------------------------------------------------------------------------
+    BoBRobotics::Net::Connection &m_Connection;
+    std::vector<Event> m_Events;
+    std::mutex m_EventMutex;
 };
 
 } // Net

--- a/include/hid/net/source.h
+++ b/include/hid/net/source.h
@@ -1,0 +1,24 @@
+#pragma once
+
+// BoB robotics includes
+#include "net/connection.h"
+
+// Standard C++ includes
+#include <sstream>
+
+namespace BoBRobotics {
+namespace HID {
+namespace Net {
+
+class Source : public JoystickBase
+{
+public:
+    Source(BoBRobotics::Net::Connection &connection)
+
+private:
+
+};
+
+} // Net
+} // HID
+} // BoBRobotics

--- a/src/hid/net/CMakeLists.txt
+++ b/src/hid/net/CMakeLists.txt
@@ -1,0 +1,6 @@
+cmake_minimum_required(VERSION 3.10)
+include(../../../cmake/BoBRobotics.cmake)
+project(hid/net)
+
+find_package(BoBRobotics REQUIRED net)
+BoB_module(sink.cc source.cc)

--- a/src/hid/net/sink.cc
+++ b/src/hid/net/sink.cc
@@ -1,0 +1,39 @@
+// BoB robotics includes
+#include "hid/net/sink.h"
+#include "net/connection.h"
+
+// Standard C++ includes
+#include <sstream>
+
+namespace BoBRobotics {
+namespace HID {
+namespace Net {
+
+Sink::Sink(BoBRobotics::Net::Connection &connection, Joystick &joystick)
+: m_Connection{ connection }
+{
+    // Add axis handler to send network event
+    joystick.addHandler(
+        [this](auto&, JAxis axis, float value)
+        {
+            std::stringstream ss;
+            ss << "JOY_AXIS " << static_cast<int>(axis) << " " << value << "\n";
+
+            m_Connection.getSocketWriter().send(ss.str());
+            return true;
+        });
+
+    // Add button handler to send network event
+    joystick.addHandler(
+        [this](auto&, JButton button, bool pressed)
+        {
+            std::stringstream ss;
+            ss << "JOY_BTN " << static_cast<int>(button) << " " << pressed << "\n";
+
+            m_Connection.getSocketWriter().send(ss.str());
+            return true;
+        });
+}
+} // Net
+} // HID
+} // BoBRobotics

--- a/src/hid/net/sink.cc
+++ b/src/hid/net/sink.cc
@@ -9,6 +9,9 @@ namespace BoBRobotics {
 namespace HID {
 namespace Net {
 
+//----------------------------------------------------------------------------
+// BoBRobotics::HID::Net::Sink
+//----------------------------------------------------------------------------
 Sink::Sink(BoBRobotics::Net::Connection &connection, Joystick &joystick)
 : m_Connection{ connection }
 {
@@ -28,7 +31,7 @@ Sink::Sink(BoBRobotics::Net::Connection &connection, Joystick &joystick)
         [this](auto&, JButton button, bool pressed)
         {
             std::stringstream ss;
-            ss << "JOY_BTN " << static_cast<size_t>(button) << " " << (pressed ? "1" : "0") << "\n";
+            ss << "JOY_BUTTON " << static_cast<size_t>(button) << " " << (pressed ? "1" : "0") << "\n";
 
             m_Connection.getSocketWriter().send(ss.str());
             return true;

--- a/src/hid/net/sink.cc
+++ b/src/hid/net/sink.cc
@@ -2,6 +2,9 @@
 #include "hid/net/sink.h"
 #include "net/connection.h"
 
+// Third party includes
+#include "plog/Log.h"
+
 // Standard C++ includes
 #include <sstream>
 
@@ -15,6 +18,10 @@ namespace Net {
 Sink::Sink(BoBRobotics::Net::Connection &connection, Joystick &joystick)
 : m_Connection{ connection }
 {
+#ifndef __linux__
+    LOGW << "Net joysticks require the same OS to be running the sink and source - be careful!";
+#endif
+
     // Add axis handler to send network event
     joystick.addHandler(
         [this](auto&, JAxis axis, float value)

--- a/src/hid/net/sink.cc
+++ b/src/hid/net/sink.cc
@@ -17,7 +17,7 @@ Sink::Sink(BoBRobotics::Net::Connection &connection, Joystick &joystick)
         [this](auto&, JAxis axis, float value)
         {
             std::stringstream ss;
-            ss << "JOY_AXIS " << static_cast<int>(axis) << " " << value << "\n";
+            ss << "JOY_AXIS " << static_cast<size_t>(axis) << " " << value << "\n";
 
             m_Connection.getSocketWriter().send(ss.str());
             return true;
@@ -28,7 +28,7 @@ Sink::Sink(BoBRobotics::Net::Connection &connection, Joystick &joystick)
         [this](auto&, JButton button, bool pressed)
         {
             std::stringstream ss;
-            ss << "JOY_BTN " << static_cast<int>(button) << " " << pressed << "\n";
+            ss << "JOY_BTN " << static_cast<size_t>(button) << " " << (pressed ? "1" : "0") << "\n";
 
             m_Connection.getSocketWriter().send(ss.str());
             return true;

--- a/src/hid/net/source.cc
+++ b/src/hid/net/source.cc
@@ -2,6 +2,9 @@
 #include "hid/net/source.h"
 #include "net/connection.h"
 
+// Third party includes
+#include "plog/Log.h"
+
 namespace BoBRobotics {
 namespace HID {
 namespace Net {
@@ -12,6 +15,10 @@ namespace Net {
 Source::Source(BoBRobotics::Net::Connection &connection)
 :   m_Connection(connection)
 {
+#ifndef __linux__
+    LOGW << "Net joysticks require the same OS to be running the sink and source - be careful!";
+#endif
+
     // Set initial state of all axes to 0.0f
     for(size_t a = 0; a < static_cast<size_t>(JAxis::LENGTH); a++) {
         setState(static_cast<JAxis>(a), 0.0f, true);
@@ -33,7 +40,8 @@ Source::Source(BoBRobotics::Net::Connection &connection)
                                        }
 
                                        // Parse event
-                                       auto &evt = m_Events.emplace_back();
+                                       m_Events.emplace_back();
+                                       auto &evt = m_Events.back();
                                        evt.axisNotButton = true;
                                        evt.axis.axis = toAxis(std::stoul(command[1]));
                                        evt.axis.value = std::stof(command[2]);
@@ -50,7 +58,8 @@ Source::Source(BoBRobotics::Net::Connection &connection)
                                        }
 
                                        // Parse event
-                                       auto &evt = m_Events.emplace_back();
+                                       m_Events.emplace_back();
+                                       auto &evt = m_Events.back();
                                        evt.axisNotButton = false;
                                        evt.button.button = toButton(std::stoul(command[1]));
                                        evt.button.pressed = (std::stoul(command[2]) != 0);

--- a/src/hid/net/source.cc
+++ b/src/hid/net/source.cc
@@ -12,6 +12,16 @@ namespace Net {
 Source::Source(BoBRobotics::Net::Connection &connection)
 :   m_Connection(connection)
 {
+    // Set initial state of all axes to 0.0f
+    for(size_t a = 0; a < static_cast<size_t>(JAxis::LENGTH); a++) {
+        setState(static_cast<JAxis>(a), 0.0f, true);
+    }
+
+    // Set initial state of all buttons to down
+    for(size_t b = 0; b < static_cast<size_t>(JButton::LENGTH); b++) {
+        setState(static_cast<JButton>(b), 0, true);
+    }
+
     // Handle incoming JOY_AXIS commands
     m_Connection.setCommandHandler("JOY_AXIS",
                                    [this](auto&, const auto &command)
@@ -43,7 +53,7 @@ Source::Source(BoBRobotics::Net::Connection &connection)
                                        m_Events.emplace_back();
                                        m_Events.back().axisNotButton = false;
                                        m_Events.back().button.button = toButton(std::stoul(command[1]));
-                                       m_Events.back().button.pressed = std::stof(command[2]);
+                                       m_Events.back().button.pressed = (std::stoul(command[2]) != 0);
                                    });
 }
 //------------------------------------------------------------------------

--- a/src/hid/net/source.cc
+++ b/src/hid/net/source.cc
@@ -33,10 +33,10 @@ Source::Source(BoBRobotics::Net::Connection &connection)
                                        }
 
                                        // Parse event
-                                       m_Events.emplace_back();
-                                       m_Events.back().axisNotButton = true;
-                                       m_Events.back().axis.axis = toAxis(std::stoul(command[1]));
-                                       m_Events.back().axis.value = std::stof(command[2]);
+                                       auto &evt = m_Events.emplace_back();
+                                       evt.axisNotButton = true;
+                                       evt.axis.axis = toAxis(std::stoul(command[1]));
+                                       evt.axis.value = std::stof(command[2]);
                                    });
 
     // Handle incoming JOY_BUTTON commands
@@ -50,10 +50,10 @@ Source::Source(BoBRobotics::Net::Connection &connection)
                                        }
 
                                        // Parse event
-                                       m_Events.emplace_back();
-                                       m_Events.back().axisNotButton = false;
-                                       m_Events.back().button.button = toButton(std::stoul(command[1]));
-                                       m_Events.back().button.pressed = (std::stoul(command[2]) != 0);
+                                       auto &evt = m_Events.emplace_back();
+                                       evt.axisNotButton = false;
+                                       evt.button.button = toButton(std::stoul(command[1]));
+                                       evt.button.pressed = (std::stoul(command[2]) != 0);
                                    });
 }
 //------------------------------------------------------------------------
@@ -71,23 +71,22 @@ bool Source::updateState()
     if(m_Events.empty()) {
         return false;
     }
-    else {
-        for(const auto &e : m_Events) {
-            if (e.axisNotButton) {
-                setState(e.axis.axis, e.axis.value, false);
-            } else {
-                if (e.button.pressed) {
-                    setPressed(e.button.button, false);
 
-                } else {
-                    setReleased(e.button.button, false);
-                }
+    for(const auto &e : m_Events) {
+        if (e.axisNotButton) {
+            setState(e.axis.axis, e.axis.value, false);
+        } else {
+            if (e.button.pressed) {
+                setPressed(e.button.button, false);
+
+            } else {
+                setReleased(e.button.button, false);
             }
         }
-
-        m_Events.clear();
-        return true;
     }
+
+    m_Events.clear();
+    return true;
 }
 } // Net
 } // HID

--- a/src/hid/net/source.cc
+++ b/src/hid/net/source.cc
@@ -1,0 +1,79 @@
+// BoB robotics includes
+#include "hid/net/source.h"
+#include "net/connection.h"
+
+namespace BoBRobotics {
+namespace HID {
+namespace Net {
+
+//----------------------------------------------------------------------------
+// BoBRobotics::HID::Net::Source
+//----------------------------------------------------------------------------
+Source::Source(BoBRobotics::Net::Connection &connection)
+:   m_Connection(connection)
+{
+    // Handle incoming JOY_AXIS commands
+    m_Connection.setCommandHandler("JOY_AXIS",
+                                   [this](auto&, const auto &command)
+                                   {
+                                       std::lock_guard<std::mutex> lock(m_EventMutex);
+
+                                       if (command.size() != 3) {
+                                           throw BoBRobotics::Net::BadCommandError();
+                                       }
+
+                                       // Parse event
+                                       m_Events.emplace_back();
+                                       m_Events.back().axisNotButton = true;
+                                       m_Events.back().axis.axis = toAxis(std::stoul(command[1]));
+                                       m_Events.back().axis.value = std::stof(command[2]);
+                                   });
+
+    // Handle incoming JOY_BUTTON commands
+    m_Connection.setCommandHandler("JOY_BUTTON",
+                                   [this](auto&, const auto &command)
+                                   {
+                                       std::lock_guard<std::mutex> lock(m_EventMutex);
+                                       if (command.size() != 3) {
+                                           throw BoBRobotics::Net::BadCommandError();
+                                       }
+
+                                       // Parse event
+                                       m_Events.emplace_back();
+                                       m_Events.back().axisNotButton = false;
+                                       m_Events.back().button.button = toButton(std::stoul(command[1]));
+                                       m_Events.back().button.pressed = std::stof(command[2]);
+                                   });
+}
+//------------------------------------------------------------------------
+Source::~Source()
+{
+    // Remove command handlers
+    m_Connection.setCommandHandler("JOY_AXIS", nullptr);
+    m_Connection.setCommandHandler("JOY_BUTTON", nullptr);
+}
+//------------------------------------------------------------------------
+bool Source::updateState()
+{
+    std::lock_guard<std::mutex> lock(m_EventMutex);
+
+    if(m_Events.empty()) {
+        return false;
+    }
+    else {
+        for(const auto &e : m_Events) {
+            if (e.axisNotButton) {
+                setState(e.axis.axis, e.axis.value, false);
+            } else {
+                setState(e.button.button, e.button.pressed ? StateDown : 0,
+                         false);
+            }
+        }
+
+        m_Events.clear();
+        return true;
+    }
+}
+} // Net
+} // HID
+} // BoBRobotics

--- a/src/hid/net/source.cc
+++ b/src/hid/net/source.cc
@@ -34,6 +34,7 @@ Source::Source(BoBRobotics::Net::Connection &connection)
                                    [this](auto&, const auto &command)
                                    {
                                        std::lock_guard<std::mutex> lock(m_EventMutex);
+
                                        if (command.size() != 3) {
                                            throw BoBRobotics::Net::BadCommandError();
                                        }
@@ -65,8 +66,12 @@ bool Source::updateState()
             if (e.axisNotButton) {
                 setState(e.axis.axis, e.axis.value, false);
             } else {
-                setState(e.button.button, e.button.pressed ? StateDown : 0,
-                         false);
+                if (e.button.pressed) {
+                    setPressed(e.button.button, false);
+
+                } else {
+                    setReleased(e.button.button, false);
+                }
             }
         }
 

--- a/tools/remote_joystick/CMakeLists.txt
+++ b/tools/remote_joystick/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.10)
+include(../../cmake/BoBRobotics.cmake)
+project(remote_joystick)
+
+find_package(BoBRobotics QUIET REQUIRED COMPONENTS hid net hid/net)
+
+add_executable(remote_joystick remote_joystick.cc)
+target_link_libraries(remote_joystick PUBLIC ${BoBRobotics_LIBRARIES})

--- a/tools/remote_joystick/remote_joystick.cc
+++ b/tools/remote_joystick/remote_joystick.cc
@@ -1,0 +1,45 @@
+// BoB robotics includes
+#include "common/background_exception_catcher.h"
+#include "hid/joystick.h"
+#include "hid/net/sink.h"
+#include "net/client.h"
+
+// Standard C++ includes
+#include <chrono>
+#include <exception>
+#include <thread>
+
+using namespace BoBRobotics;
+using namespace std::literals;
+
+int bobMain(int, char **)
+{
+    // Enable networking on Windows
+    OS::Net::WindowsNetworking::initialise();
+
+    // Make connection to robot on default port
+    Net::Client client;
+
+    // Create joystick
+    HID::Joystick joystick;
+
+    // Transmit motor commands over network
+    HID::Net::Sink sink(client, joystick);
+
+    // Run client on background thread, catching any exceptions for rethrowing
+    BackgroundExceptionCatcher catcher;
+    catcher.trapSignals(); // Catch Ctrl-C
+    client.runInBackground();
+
+    while (!joystick.isPressed(HID::JButton::X)) {
+        // Rethrow any exceptions caught on background thread
+        catcher.check();
+
+        // Poll joystick
+        joystick.update();
+
+        std::this_thread::sleep_for(100ms);
+    }
+
+    return EXIT_SUCCESS;
+}

--- a/tools/remote_joystick/remote_joystick.cc
+++ b/tools/remote_joystick/remote_joystick.cc
@@ -31,7 +31,7 @@ int bobMain(int, char **)
     catcher.trapSignals(); // Catch Ctrl-C
     client.runInBackground();
 
-    while (!joystick.isPressed(HID::JButton::X)) {
+    while (true) {
         // Rethrow any exceptions caught on background thread
         catcher.check();
 


### PR DESCRIPTION
We have been previously using remote tank and friends quite happily for sending pure tank steering commands over the network but, because our ATV robot is encased in a big metal box and tends to outrun the xbox controller we need to be able to send button presses etc as well as do different things with input in different states.  So...in this PR I have implemented network sinks for joystick events (HID devices in BoB parlance).  I have made a ``remote_joystick`` 'tool' for running on a laptop and an example which polls the joystick and prints out events.

This is the deepest I've delved in BoB robotics for a while so any thoughts would be much appreciated! The only real gotcha is that, due to the way the joystick code is structured, the source and sink need to be running on the same OS (or at least their windowsness needs to match) but I don't think that's much of an issue. We could do something smarter with the initial state but I also think this is fine for now.